### PR TITLE
@Remo: Removed crufty extensons list, added v1 vs v2 link to main summary in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ This is the master repository for Ninject, the lightweight and lightning-fast .N
 _If you're reading blog posts or books from before 2010, they're likely to be regarding version 1, which has [some key improvements, summarised in the wiki](https://github.com/ninject/ninject/wiki/Changes-in-Ninject-2)_
 
 - [Project website](http://ninject.org/)
-- [Documentation](http://dojo.ninject.org/)
+- [Documentation](http://ninject.org/learn)
 - [Nate's blog](http://kohari.org/)
 
 Ninject is a lightning-fast, ultra-lightweight dependency injector for .NET applications. It helps you split your


### PR DESCRIPTION
Have done some minor edits to wiki itself too, but I reckon based on SO traffic, these two points are critical to get in (assuming that the readme.markdown is a key secondary landing page for the project)

Feel free to be selective though - this page can def benefit from more brevity and less duplication, not more!
