### PR TITLE
Transient missing bindings

### DIFF
--- a/src/Ninject/Infrastructure/Introspection/ExceptionFormatter.cs
+++ b/src/Ninject/Infrastructure/Introspection/ExceptionFormatter.cs
@@ -33,7 +33,7 @@ namespace Ninject.Infrastructure.Introspection
         }
 
         /// <summary>
-        /// Generates a message saying that modules without names are not supported.
+        /// Generates a message saying that the target does not have a default value.
         /// </summary>
         /// <returns>The exception message.</returns>
         public static string TargetDoesNotHaveADefaultValue(ITarget target)

--- a/src/Ninject/Planning/Bindings/Resolvers/SelfBindingResolver.cs
+++ b/src/Ninject/Planning/Bindings/Resolvers/SelfBindingResolver.cs
@@ -42,7 +42,8 @@ namespace Ninject.Planning.Bindings.Resolvers
                         {
                             new Binding(service)
                             {
-                                ProviderCallback = StandardProvider.GetCreationCallback(service)
+                                ProviderCallback = StandardProvider.GetCreationCallback(service),
+                                IsImplicit = true, // adds the binding to the binding map
                             }
                         };
         }


### PR DESCRIPTION
This keeps bindings resolved through an IMissingBindingResolver from being added to the binding map unless they are marked to do so (by setting IsImplicit = true).

Note: This does slightly change functionality.  Now IMBR bindings that are transient (not saved) are not marked as Implicit.  This should be fine as only the KernelBase really can see them at this point (and there are no other explicit bindings to speak of) however it does change the sort order should an IMBR return bindings where some are marked as Implicit and some aren't.  Since there was never any reason for an IMBR to return something as Implicit (unless it was also an IBindingResolver) this shouldn't impact anything. Also, previously an IMBR could return a list of bindings that didn't apply; now if they do that we ignore them and keep trying.

Net result, for IMBRs where it makes sense to save the binding (i.e. SelfBindingResolver) those bindings are saved. For IMBRs where it makes less sense (DefaultValueBindingResolver) because it can target multiple services (and grow the cache) we don't save the binding.

I feel ever so slightly dirty using IsImplicit as the marker for this new behavior.  I would feel dirtier creating a new property for it.  Probably better to use some out-of-band marker (wrapper class, different methods, different interfaces) but that would break compatibility with existing IMBRs.  At least here existing IMBRs still work (they become transient, the safest default).
