### PR TITLE
WeakReference race conditions

### DIFF
--- a/src/Ninject/Activation/Context.cs
+++ b/src/Ninject/Activation/Context.cs
@@ -124,7 +124,7 @@ namespace Ninject.Activation
                 this.cachedScope = new WeakReference(scope);
             }
             
-            return this.cachedScope.IsAlive ? this.cachedScope.Target : null;
+            return this.cachedScope.Target;
         }
 
         /// <summary>

--- a/src/Ninject/Infrastructure/ReferenceEqualWeakReference.cs
+++ b/src/Ninject/Infrastructure/ReferenceEqualWeakReference.cs
@@ -90,24 +90,25 @@ namespace Ninject.Infrastructure
             var referenceEqualWeakReference = obj as ReferenceEqualWeakReference;
             if (referenceEqualWeakReference != null)
             {
-                if (!referenceEqualWeakReference.IsAlive)
+                obj = referenceEqualWeakReference.Target;
+
+                if (obj == null)
                 {
                     return false;
                 }
 
-                obj = referenceEqualWeakReference.Target;
             }
             else
             {
                 var weakReference = obj as WeakReference;
                 if (weakReference != null)
                 {
-                    if (!weakReference.IsAlive)
+                    obj = weakReference.Target;
+
+                    if (obj == null)
                     {
                         return false;
                     }
-
-                    obj = weakReference.Target;
                 }
             }
 
@@ -122,9 +123,10 @@ namespace Ninject.Infrastructure
         /// </returns>
         public override int GetHashCode()
         {
-            if (this.IsAlive)
+            var target = this.Target;
+            if (target != null)
             {
-                this.cashedHashCode = this.Target.GetHashCode();
+                this.cashedHashCode = target.GetHashCode();
             }
 
             return this.cashedHashCode;


### PR DESCRIPTION
I noticed a couple of places where WeakReferences were used in a way that could cause a race condition with the Garbage Collector.  Proper usage is to pull out a reference to the target (which may end up being null) then checking whether the reference is still alive (or just check the value for null) otherwise the target can be collected in between the call to .IsAlive and .Target.
