### PR TITLE
Fix for possible race condition in Planner.GetPlan

### DIFF
--- a/src/Ninject/KernelBase.cs
+++ b/src/Ninject/KernelBase.cs
@@ -285,10 +285,7 @@ namespace Ninject
             var request = this.CreateRequest(service, null, parameters, false, false);
             var context = this.CreateContext(request, binding);
 
-            lock (planner)
-            {
-                context.Plan = planner.GetPlan(service);
-            }
+            context.Plan = planner.GetPlan(service);
 
             var reference = new InstanceReference { Instance = instance };
             pipeline.Activate(context, reference);

--- a/src/Ninject/Planning/Planner.cs
+++ b/src/Ninject/Planning/Planner.cs
@@ -50,13 +50,9 @@ namespace Ninject.Planning
         {
             Ensure.ArgumentNotNull(type, "type");
 
-            IPlan plan;
-            if (plans.TryGetValue(type, out plan))
-            {
-                return plan;
-            }
             lock (plans)
             {
+                IPlan plan;
                 if (plans.TryGetValue(type, out plan))
                 {
                     return plan;


### PR DESCRIPTION
The current implementation of Planner.GetPlan uses double-checked locking on a Dictionary to retrieve a plan from the cache, which is not thread-safe. One of the use cases does lock the entire planner (KernelBase.Inject), preventing the race condition if Planner is only called from that method, but other methods call GetPlan without locking the planner first.

See here:
http://blogs.msdn.com/b/kimhamil/archive/2008/03/08/hashtable-and-dictionary-thread-safety-considerations.aspx
Another discussion of the topic:
http://www.grumpydev.com/2010/02/25/thread-safe-dictionarytkeytvalue/
