### PR TITLE
Mirror the conditions where HashSet implementation is provided to match ...

### DIFF
--- a/src/Ninject/Components/ComponentContainer.cs
+++ b/src/Ninject/Components/ComponentContainer.cs
@@ -215,14 +215,14 @@ namespace Ninject.Components
             return constructor;
         }
 
-#if SILVERLIGHT_30 || SILVERLIGHT_20 || WINDOWS_PHONE || NETCF_35
+#if SILVERLIGHT_30 || SILVERLIGHT_20 || WINDOWS_PHONE || NETCF_35 || MONO
         private class HashSet<T>
         {
-            private IDictionary<T, object> data = new Dictionary<T,object>();
+            private IDictionary<T, object> data = new Dictionary<T,bool>();
  
             public void Add(T o)
             {
-                this.data.Add(o, null);
+                this.data.Add(o, true);
             }
 
             public bool Contains(T o)


### PR DESCRIPTION
...the compilation conditions in ActivationCache.cs (added MONO)

Switch to storing a (bool)true in the HashSet to reduce object references (even if always null) that the garbage collector must walk.

Possibly should generically expose this for internal use by other HashSet-replacement needs in Ninject.
