### PR TITLE
Fix InvalidOperationException on ToConstructor binding

### DIFF
--- a/src/Ninject.Test/Integration/ConstructorSelectionTests.cs
+++ b/src/Ninject.Test/Integration/ConstructorSelectionTests.cs
@@ -156,21 +156,21 @@ namespace Ninject.Tests.Integration
         }
 #endif
 
-		private static Ninja CreateNinja()
-		{
-			return new Ninja(new Sword());
-		}
+        private static Ninja CreateNinja()
+        {
+            return new Ninja(new Sword());
+        }
 
-		[Fact]
-		public void ResultsFromNonGenericMethodCallsCanBePassedToToConstructor()
-		{
-			kernel.Bind<Barracks>().ToConstructor(_ => new Barracks(CreateNinja()));
+        [Fact]
+        public void ResultsFromNonGenericMethodCallsCanBePassedToToConstructor()
+        {
+            kernel.Bind<Barracks>().ToConstructor(_ => new Barracks(CreateNinja()));
 
-			var barracks1 = kernel.Get<Barracks>();
-			var barracks2 = kernel.Get<Barracks>();
+            var barracks1 = kernel.Get<Barracks>();
+            var barracks2 = kernel.Get<Barracks>();
 
-			barracks1.Warrior.Should().NotBeSameAs(barracks2.Warrior);
-		}
+            barracks1.Warrior.Should().NotBeSameAs(barracks2.Warrior);
+        }
 
         [Fact]
         public void WhenLazyValuesArePassedToConstrctorSelectionTheyAreEvaluatedAtResolve()

--- a/src/Ninject/Planning/Bindings/BindingBuilder.cs
+++ b/src/Ninject/Planning/Bindings/BindingBuilder.cs
@@ -219,7 +219,7 @@ namespace Ninject.Planning.Bindings
         {
             var methodCall = argument as MethodCallExpression;
             if (methodCall == null ||
-				!methodCall.Method.IsGenericMethod ||
+                !methodCall.Method.IsGenericMethod ||
                 methodCall.Method.GetGenericMethodDefinition().DeclaringType != typeof(IConstructorArgumentSyntax))
             {
                 var compiledExpression = Expression.Lambda(argument, constructorArgumentSyntaxParameterExpression).Compile();


### PR DESCRIPTION
Fix InvalidOperationException when invoking non-generic methods to get arguments on ToConstructor binding.
