### PR TITLE
Spelling error in docs

### DIFF
--- a/src/Ninject/Syntax/IBindingToSyntax{T1}.cs
+++ b/src/Ninject/Syntax/IBindingToSyntax{T1}.cs
@@ -110,7 +110,7 @@ namespace Ninject.Syntax
 
 #if !NETCF
         /// <summary>
-        /// Indicates that the service should be bound to the speecified constructor.
+        /// Indicates that the service should be bound to the specified constructor.
         /// </summary>
         /// <typeparam name="TImplementation">The type of the implementation.</typeparam>
         /// <param name="newExpression">The expression that specifies the constructor.</param>


### PR DESCRIPTION
Fixed a spelling error in ToConstant<TImplementation> method summary.
