### PR TITLE
issue #89 - including matching bindings on failed resolve due to multiple bindings

### DIFF
--- a/src/Ninject.Test/Integration/StandardKernelTests.cs
+++ b/src/Ninject.Test/Integration/StandardKernelTests.cs
@@ -46,6 +46,8 @@
             var exception = Assert.Throws<ActivationException>(() => kernel.Get<IWeapon>());
             
             exception.Message.Should().Contain("More than one matching bindings are available.");
+            exception.Message.Should().Contain("1) binding from IWeapon to Sword");
+            exception.Message.Should().Contain("2) binding from IWeapon to Shuriken");
         }
 
         [Fact]

--- a/src/Ninject/Infrastructure/Introspection/ExceptionFormatter.cs
+++ b/src/Ninject/Infrastructure/Introspection/ExceptionFormatter.cs
@@ -103,14 +103,20 @@ namespace Ninject.Infrastructure.Introspection
         /// Generates a message saying that the binding could not be uniquely resolved.
         /// </summary>
         /// <param name="request">The request.</param>
+        /// <param name="formattedMatchingBindings">The matching bindings, already formatted as strings</param>
         /// <returns>The exception message.</returns>
-        public static string CouldNotUniquelyResolveBinding(IRequest request)
+        public static string CouldNotUniquelyResolveBinding(IRequest request, string[] formattedMatchingBindings)
         {
             using (var sw = new StringWriter())
             {
                 sw.WriteLine("Error activating {0}", request.Service.Format());
                 sw.WriteLine("More than one matching bindings are available.");
 
+                sw.WriteLine("Matching bindings:");
+                for (int i = 0; i < formattedMatchingBindings.Length; i++)
+                {
+                    sw.WriteLine("  {0}) {1}", i + 1, formattedMatchingBindings[i]);
+                }
                 sw.WriteLine("Activation path:");
                 sw.WriteLine(request.FormatActivationPath());
 

--- a/src/Ninject/KernelBase.cs
+++ b/src/Ninject/KernelBase.cs
@@ -373,7 +373,11 @@ namespace Ninject
                         return Enumerable.Empty<object>();
                     }
 
-                    throw new ActivationException(ExceptionFormatter.CouldNotUniquelyResolveBinding(request));
+                    var formattedBindings =
+                        from binding in resolveBindings
+                        let context = this.CreateContext(request, binding)
+                        select binding.Format(context);
+                    throw new ActivationException(ExceptionFormatter.CouldNotUniquelyResolveBinding(request, formattedBindings.ToArray()));
                 }
             }
 


### PR DESCRIPTION
This includes the list of matching bindings for the case of Resolve failing due to multiple matching bindings.  This additional detail makes the situation much faster and easier for a user of ninject to diagnose and fix their binding configuration. :)
