### PR TITLE
test and fix for CommonServiceLocator.NinjectAdapter and named bindings

### DIFF
--- a/Ninject.sln
+++ b/Ninject.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestModules", "src\TestModu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestAssembly", "src\TestAssembly\TestAssembly.csproj", "{C9F6CFE7-44B2-4D55-9307-33C34C045468}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonServiceLocator.NinjectAdapter.Tests", "src\CommonServiceLocator.NinjectAdapter.Tests\CommonServiceLocator.NinjectAdapter.Tests.csproj", "{3B703A23-DB64-4606-B124-16BA83C461B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		AutomatedRelease|Any CPU = AutomatedRelease|Any CPU
@@ -67,6 +69,14 @@ Global
 		{C9F6CFE7-44B2-4D55-9307-33C34C045468}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9F6CFE7-44B2-4D55-9307-33C34C045468}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9F6CFE7-44B2-4D55-9307-33C34C045468}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.AutomatedRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.AutomatedRelease|Any CPU.Build.0 = Release|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.Debug .NET 4.0|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.Debug .NET 4.0|Any CPU.Build.0 = Debug|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B703A23-DB64-4606-B124-16BA83C461B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CommonServiceLocator.NinjectAdapter.Tests/CommonServiceLocator.NinjectAdapter.Tests.csproj
+++ b/src/CommonServiceLocator.NinjectAdapter.Tests/CommonServiceLocator.NinjectAdapter.Tests.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3B703A23-DB64-4606-B124-16BA83C461B2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CommonServiceLocator.NinjectAdapter.Tests</RootNamespace>
+    <AssemblyName>CommonServiceLocator.NinjectAdapter.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FluentAssertions">
+      <HintPath>..\..\tools\FluentAssertions\Net-3.5\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\..\lib\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\..\tools\xunit.net\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NinjectServiceLocatorTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CommonServiceLocator.NinjectAdapter\CommonServiceLocator.NinjectAdapter.csproj">
+      <Project>{9BD94717-484B-4EB1-AF32-8D4244F02E8E}</Project>
+      <Name>CommonServiceLocator.NinjectAdapter</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Ninject\Ninject.csproj">
+      <Project>{ADF369E2-6B9E-4D56-9B82-D273AE41EC2D}</Project>
+      <Name>Ninject</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/CommonServiceLocator.NinjectAdapter.Tests/NinjectServiceLocatorTests.cs
+++ b/src/CommonServiceLocator.NinjectAdapter.Tests/NinjectServiceLocatorTests.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using Microsoft.Practices.ServiceLocation;
+using Ninject;
+using Ninject.Infrastructure.Disposal;
+using Xunit;
+
+namespace CommonServiceLocator.NinjectAdapter.Tests
+{
+    public interface IFoo { }
+    public class Foo : IFoo { }
+
+    public class NinjectServiceLocatorTests : DisposableObject
+    {
+        protected IKernel kernel;
+
+        [Fact]
+        public void DefaultInstanceIsResolvedWhenNoKeySpecified()
+        {
+            this.kernel = new StandardKernel();
+            ServiceLocator.SetLocatorProvider(() => new NinjectServiceLocator(kernel));
+
+            this.kernel.Bind<IFoo>().To<Foo>().Named("SomeFoo");
+
+            // CommonServiceLocator requires that the named binding still be used.
+            // http://commonservicelocator.codeplex.com/wikipage?title=API%20Reference&referringTitle=Home
+            var instance = ServiceLocator.Current.GetInstance<IFoo>();
+
+            instance.Should().NotBeNull();
+            instance.Should().BeOfType<Foo>();
+        }
+
+        public override void Dispose( bool disposing )
+        {
+            if ( disposing && !IsDisposed )
+            {
+                this.kernel.Dispose();
+                this.kernel = null;
+            }
+            base.Dispose( disposing );
+        }
+    }
+}

--- a/src/CommonServiceLocator.NinjectAdapter.Tests/Properties/AssemblyInfo.cs
+++ b/src/CommonServiceLocator.NinjectAdapter.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CommonServiceLocator.NinjectAdapter.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("CommonServiceLocator.NinjectAdapter.Tests")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e7966d89-10cc-4ce4-9f72-ffac0ae6e350")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/CommonServiceLocator.NinjectAdapter/NinjectServiceLocator.cs
+++ b/src/CommonServiceLocator.NinjectAdapter/NinjectServiceLocator.cs
@@ -27,6 +27,15 @@ namespace CommonServiceLocator.NinjectAdapter
 
         protected override object DoGetInstance(Type serviceType, string key)
         {
+            // key == null must be specifically handled as not asking for a specific keyed instance
+            // http://commonservicelocator.codeplex.com/wikipage?title=API%20Reference&referringTitle=Home
+            //     The implementation should be designed to expect a null for the string key parameter, 
+            //     and MUST interpret this as a request to get the "default" instance for the requested 
+            //     type. This meaning of default varies from locator to locator.
+            if (key == null)
+            {
+                return Kernel.Get(serviceType);
+            }
             return Kernel.Get(serviceType, key);
         }
 


### PR DESCRIPTION
The CommonServiceLocator specifies that calling its non-keyed
interface will call the keyed interface with a value of key == null.
It also states that when a key is passed as null, it needs to be
handled as returned the 'default' instance.  Because of this, we
need to handle the key == null case specifically.  Without this
change, the newly added test fails as it attempts to find a binding
with a name of "" (empty string).
