### PR TITLE
Update Ninject.sln to reference README.md

### DIFF
--- a/Ninject.sln
+++ b/Ninject.sln
@@ -8,7 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build-release.cmd = build-release.cmd
 		build.cmd = build.cmd
 		LICENSE.txt = LICENSE.txt
-		README.markdown = README.markdown
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ninject", "src\Ninject\Ninject.csproj", "{ADF369E2-6B9E-4D56-9B82-D273AE41EC2D}"


### PR DESCRIPTION
After the rename of README.markdown to README.md (f884f9998), the file's link in the solution file was orphaned leading to an error when trying to open it.

![image](https://cloud.githubusercontent.com/assets/1066014/4799220/cfd81836-5e1a-11e4-8919-d640f9a8b8df.png)
