### PR TITLE
add missing null checks to public constructors

### DIFF
--- a/src/Ninject/Activation/Caching/ActivationCache.cs
+++ b/src/Ninject/Activation/Caching/ActivationCache.cs
@@ -39,6 +39,7 @@ namespace Ninject.Activation.Caching
         /// <param name="cachePruner">The cache pruner.</param>
         public ActivationCache(ICachePruner cachePruner)
         {
+            Ensure.ArgumentNotNull(cachePruner, "cachePruner");
             cachePruner.Start(this);
         }
         

--- a/src/Ninject/Activation/Pipeline.cs
+++ b/src/Ninject/Activation/Pipeline.cs
@@ -36,6 +36,7 @@ namespace Ninject.Activation
         public Pipeline(IEnumerable<IActivationStrategy> strategies, IActivationCache activationCache)
         {
             Ensure.ArgumentNotNull(strategies, "strategies");
+            Ensure.ArgumentNotNull(activationCache, "activationCache");
             this.Strategies = strategies.ToList();
             this.activationCache = activationCache;
         }
@@ -53,6 +54,7 @@ namespace Ninject.Activation
         public void Activate(IContext context, InstanceReference reference)
         {
             Ensure.ArgumentNotNull(context, "context");
+            Ensure.ArgumentNotNull(reference, "reference");
             if (!this.activationCache.IsActivated(reference.Instance))
             {
                 this.Strategies.Map(s => s.Activate(context, reference));
@@ -67,6 +69,7 @@ namespace Ninject.Activation
         public void Deactivate(IContext context, InstanceReference reference)
         {
             Ensure.ArgumentNotNull(context, "context");
+            Ensure.ArgumentNotNull(reference, "reference");
             if (!this.activationCache.IsDeactivated(reference.Instance))
             {
                 this.Strategies.Map(s => s.Deactivate(context, reference));

--- a/src/Ninject/Activation/Strategies/ActivationCacheStrategy.cs
+++ b/src/Ninject/Activation/Strategies/ActivationCacheStrategy.cs
@@ -1,6 +1,7 @@
 namespace Ninject.Activation.Strategies
 {
     using Ninject.Activation.Caching;
+    using Ninject.Infrastructure;
 
     /// <summary>
     /// Adds all activated instances to the activation cache.
@@ -18,6 +19,7 @@ namespace Ninject.Activation.Strategies
         /// <param name="activationCache">The activation cache.</param>
         public ActivationCacheStrategy(IActivationCache activationCache)
         {
+            Ensure.ArgumentNotNull(activationCache, "activationCache");
             this.activationCache = activationCache;
         }
 

--- a/src/Ninject/Modules/CompiledModuleLoaderPlugin.cs
+++ b/src/Ninject/Modules/CompiledModuleLoaderPlugin.cs
@@ -55,6 +55,7 @@ namespace Ninject.Modules
         public CompiledModuleLoaderPlugin(IKernel kernel, IAssemblyNameRetriever assemblyNameRetriever)
         {
             Ensure.ArgumentNotNull(kernel, "kernel");
+            Ensure.ArgumentNotNull(assemblyNameRetriever, "assemblyNameRetriever");
             this.Kernel = kernel;
             this.assemblyNameRetriever = assemblyNameRetriever;
         }


### PR DESCRIPTION
Hello, I'm working on a static analysis tool that looks for missing null checks.  It suggested you add these checks:

Reasons:

ActivationCache constructor: if cachePruner is null, the constructor will always throw an exception

Pipeline constructor: fs activationCache is null and subsequently Activate or Deactivate is called, it will throw an exception (because Activate and Deactive both dereference activationCache)

ActivationCacheStrategy constructor: if activationCache is null and subsequently Activate or Deactivate is called, it will throw an exception (because Activate and Deactive both dereference activationCache)

CompiledModuleLoaderPlugin constructor: if assemblyNameRetriever is null and subsequently LoadModules is called, it will throw an exception because LoadModules dereferences assemblyNameRetriever