### PR TITLE
Added Decorate() method to KernalBase

### DIFF
--- a/src/Ninject/KernelBase.cs
+++ b/src/Ninject/KernelBase.cs
@@ -599,5 +599,23 @@ namespace Ninject
                 return q.FirstOrDefault();
             }
         }
+        
+        /// <summary>
+        /// Decorates one type with another
+        /// </summary>
+        /// <typeparam name="DecorateThis">The type to be decorated</typeparam>
+        /// <typeparam name="WithThis">The decorator that must inherit from the type it is decorating</typeparam>
+        /// <returns>The resulting binding</returns>
+        public IBindingWhenInNamedWithOrOnSyntax<WithThis> Decorate<DecorateThis, WithThis>()
+            where WithThis : DecorateThis
+        {
+            var binding = GetBindings(typeof(DecorateThis))
+                .Last();
+            var lowerBinding = new BindingConfigurationBuilder<DecorateThis>(binding
+                .BindingConfiguration, binding.Metadata.Name, this);
+            var bindingSyntax = Bind<DecorateThis>();
+            lowerBinding.WhenInjectedInto<WithThis>();
+            return bindingSyntax.To<WithThis>();
+        }
     }
 }


### PR DESCRIPTION
Hi guys,

Firstly I'm relatively new to Ninject so I don't pretent to understand all of the functionality. Also a big thanks to everyone who has contributed to this project :-)

When I started using it one thing I really wanted was to be able to easily decorate a registered type with another type, so I could pass the decorated type into the constructor of the decorator. I know I can achieve this, but the examples I've seen require the decorator to be declared with the class it is decorating. I wanted to simply apply each class one on top of the next in a pipeline, in quite a loosely coupled way, but specifically without the decorator knowing the concrete class it is decorating.

With the code I've added I can now do this like so:

    var _module = new StandardKernel();
    _module.Bind<IT>().To<T1>().Named("x1");
    _module.Decorate<IT, T2>().Named("x2");
    _module.Decorate<IT, T3>().Named("x3");
    var obj = _module.Get<IT>();
    obj.Call(); //Invokes T3 -> Call();

Given the code below

public class T1 : IT
    {
        public void Call()
        {
            Console.WriteLine("T1");
        }
    }

    public class T2 : IT
    {       
        private IT _t;

        public T2(IT t)
        {
            _t = t;
        }
        public void Call()
        {
            _t.Call();
            Console.WriteLine("T2");
        }
    }

    public class T3 : IT
    {
        private IT _t;

        public T3(IT t)
        {
            _t = t;
        }
        public void Call()
        {
            _t.Call();
            Console.WriteLine("T3");
        }
    }
    
    public interface IT
    {
        void Call();
    }

I'm not sure if this would be of any use to the community (if not perhaps it can be adapted slightly?), but I wanted to share just in case.

Thanks