### PR TITLE
added IHaveBindingRoot interface ...

### DIFF
--- a/src/Ninject/IHaveBindingRoot.cs
+++ b/src/Ninject/IHaveBindingRoot.cs
@@ -1,0 +1,15 @@
+﻿using Ninject.Syntax;
+
+namespace Ninject
+{
+    /// <summary>
+    /// Indicates the object has a reference to a <see cref="IBindingRoot"/>.
+    /// </summary>
+    public interface IHaveBindingRoot
+    {
+        /// <summary>
+        /// Gets the associated binding root.
+        /// </summary>
+        IBindingRoot BindingRoot { get; }
+    }
+}

--- a/src/Ninject/Ninject.Android.csproj
+++ b/src/Ninject/Ninject.Android.csproj
@@ -104,6 +104,7 @@
     <Compile Include="GlobalKernelRegistration.cs" />
     <Compile Include="GlobalKernelRegistrationModule.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Ninject.Net45.csproj
+++ b/src/Ninject/Ninject.Net45.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Components\INinjectComponent.cs" />
     <Compile Include="Components\NinjectComponent.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Ninject.WinRT.csproj
+++ b/src/Ninject/Ninject.WinRT.csproj
@@ -91,6 +91,7 @@
     <Compile Include="GlobalKernelRegistration.cs" />
     <Compile Include="GlobalKernelRegistrationModule.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Ninject.Wpa81.csproj
+++ b/src/Ninject/Ninject.Wpa81.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Components\INinjectComponent.cs" />
     <Compile Include="Components\NinjectComponent.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Ninject.csproj
+++ b/src/Ninject/Ninject.csproj
@@ -116,6 +116,7 @@
     <Compile Include="GlobalKernelRegistration.cs" />
     <Compile Include="GlobalKernelRegistrationModule.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Ninject.iOS-Unified.csproj
+++ b/src/Ninject/Ninject.iOS-Unified.csproj
@@ -103,6 +103,7 @@
     <Compile Include="GlobalKernelRegistration.cs" />
     <Compile Include="GlobalKernelRegistrationModule.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Ninject.iOS.csproj
+++ b/src/Ninject/Ninject.iOS.csproj
@@ -97,6 +97,7 @@
     <Compile Include="GlobalKernelRegistration.cs" />
     <Compile Include="GlobalKernelRegistrationModule.cs" />
     <Compile Include="IBindingPrecedenceComparer.cs" />
+    <Compile Include="IHaveBindingRoot.cs" />
     <Compile Include="IHaveNinjectComponents.cs" />
     <Compile Include="IHaveNinjectSettings.cs" />
     <Compile Include="IInitializable.cs" />

--- a/src/Ninject/Planning/Bindings/BindingBuilder.cs
+++ b/src/Ninject/Planning/Bindings/BindingBuilder.cs
@@ -42,9 +42,10 @@ namespace Ninject.Planning.Bindings
         /// <param name="bindingConfiguration">The binding to build.</param>
         /// <param name="settings">The ninject configuration settings.</param>
         /// <param name="serviceNames">The names of the services.</param>
-        public BindingBuilder(IBindingConfiguration bindingConfiguration, INinjectSettings settings, string serviceNames)
+        public BindingBuilder(IBindingConfiguration bindingConfiguration, IBindingRoot bindingRoot, INinjectSettings settings, string serviceNames)
         {
             this.BindingConfiguration = bindingConfiguration;
+            this.BindingRoot = bindingRoot;
             this.ServiceNames = serviceNames;
             this.BindingConfiguration.ScopeCallback = settings.DefaultScopeCallback;
         }
@@ -53,6 +54,11 @@ namespace Ninject.Planning.Bindings
         /// Gets the binding being built.
         /// </summary>
         public IBindingConfiguration BindingConfiguration { get; private set; }
+
+        /// <summary>
+        /// Gets the associated binding root.
+        /// </summary>
+        public IBindingRoot BindingRoot { get; private set; }
 
         /// <summary>
         /// Gets the names of the services.
@@ -81,7 +87,7 @@ namespace Ninject.Planning.Bindings
             StandardProvider.AssignProviderCallback(this.BindingConfiguration, implementation);
             this.BindingConfiguration.Target = BindingTarget.Type;
 
-            return new BindingConfigurationBuilder<T>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<T>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
         
         /// <summary>
@@ -97,7 +103,7 @@ namespace Ninject.Planning.Bindings
             this.BindingConfiguration.Target = BindingTarget.Constant;
             this.BindingConfiguration.ScopeCallback = StandardScopeCallbacks.Singleton;
 
-            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>
@@ -112,7 +118,7 @@ namespace Ninject.Planning.Bindings
             this.BindingConfiguration.ProviderCallback = ctx => callbackProvider;
             this.BindingConfiguration.Target = BindingTarget.Method;
 
-            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>
@@ -126,7 +132,7 @@ namespace Ninject.Planning.Bindings
             this.BindingConfiguration.ProviderCallback = ctx => provider;
             this.BindingConfiguration.Target = BindingTarget.Provider;
 
-            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>
@@ -142,7 +148,7 @@ namespace Ninject.Planning.Bindings
             this.BindingConfiguration.ProviderCallback = ctx => ctx.Kernel.Get<TProvider>();
             this.BindingConfiguration.Target = BindingTarget.Provider;
 
-            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>
@@ -157,7 +163,7 @@ namespace Ninject.Planning.Bindings
             this.BindingConfiguration.ProviderCallback = ctx => ctx.Kernel.Get(providerType) as IProvider;
             this.BindingConfiguration.Target = BindingTarget.Provider;
 
-            return new BindingConfigurationBuilder<T>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<T>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>
@@ -179,7 +185,7 @@ namespace Ninject.Planning.Bindings
             this.BindingConfiguration.Target = BindingTarget.Type;
             this.AddConstructorArguments(ctorExpression, newExpression.Parameters[0]);
 
-            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<TImplementation>(this.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>

--- a/src/Ninject/Planning/Bindings/BindingBuilder{T1,T2,T3,T4}.cs
+++ b/src/Ninject/Planning/Bindings/BindingBuilder{T1,T2,T3,T4}.cs
@@ -44,8 +44,8 @@ namespace Ninject.Planning.Bindings
         /// <param name="bindingConfigurationConfiguration">The binding to build.</param>
         /// <param name="settings">The ninject configuration settings.</param>
         /// <param name="serviceNames">The names of the services.</param>
-        public BindingBuilder(IBindingConfiguration bindingConfigurationConfiguration, INinjectSettings settings, string serviceNames)
-            : base(bindingConfigurationConfiguration, settings, serviceNames)
+        public BindingBuilder(IBindingConfiguration bindingConfigurationConfiguration, IBindingRoot bindingRoot, INinjectSettings settings, string serviceNames)
+            : base(bindingConfigurationConfiguration, bindingRoot, settings, serviceNames)
         {
         }
 #pragma warning restore 1584

--- a/src/Ninject/Planning/Bindings/BindingBuilder{T1,T2,T3}.cs
+++ b/src/Ninject/Planning/Bindings/BindingBuilder{T1,T2,T3}.cs
@@ -43,8 +43,8 @@ namespace Ninject.Planning.Bindings
         /// <param name="bindingConfigurationConfiguration">The binding to build.</param>
         /// <param name="settings">The ninject configuration settings.</param>
         /// <param name="serviceNames">The names of the services.</param>
-        public BindingBuilder(IBindingConfiguration bindingConfigurationConfiguration, INinjectSettings settings, string serviceNames)
-            : base(bindingConfigurationConfiguration, settings, serviceNames)
+        public BindingBuilder(IBindingConfiguration bindingConfigurationConfiguration, IBindingRoot bindingRoot, INinjectSettings settings, string serviceNames)
+            : base(bindingConfigurationConfiguration, bindingRoot, settings, serviceNames)
         {
         }
 #pragma warning restore 1584

--- a/src/Ninject/Planning/Bindings/BindingBuilder{T1,T2}.cs
+++ b/src/Ninject/Planning/Bindings/BindingBuilder{T1,T2}.cs
@@ -42,8 +42,8 @@ namespace Ninject.Planning.Bindings
         /// <param name="bindingConfigurationConfiguration">The binding to build.</param>
         /// <param name="settings">The ninject configuration settings.</param>
         /// <param name="serviceNames">The names of the services.</param>
-        public BindingBuilder(IBindingConfiguration bindingConfigurationConfiguration, INinjectSettings settings, string serviceNames)
-            : base(bindingConfigurationConfiguration, settings, serviceNames)
+        public BindingBuilder(IBindingConfiguration bindingConfigurationConfiguration, IBindingRoot bindingRoot, INinjectSettings settings, string serviceNames)
+            : base(bindingConfigurationConfiguration, bindingRoot, settings, serviceNames)
         {
         }
 #pragma warning restore 1584

--- a/src/Ninject/Planning/Bindings/BindingBuilder{T1}.cs
+++ b/src/Ninject/Planning/Bindings/BindingBuilder{T1}.cs
@@ -43,8 +43,8 @@ namespace Ninject.Planning.Bindings
         /// <param name="binding">The binding to build.</param>
         /// <param name="settings">The ninject configuration settings.</param>
         /// <param name="serviceNames">The names of the services.</param>
-        public BindingBuilder(IBinding binding, INinjectSettings settings, string serviceNames)
-            : base(binding.BindingConfiguration, settings, serviceNames)
+        public BindingBuilder(IBinding binding, IBindingRoot bindingRoot, INinjectSettings settings, string serviceNames)
+            : base(binding.BindingConfiguration, bindingRoot, settings, serviceNames)
         {
             this.Binding = binding;
         }
@@ -64,7 +64,7 @@ namespace Ninject.Planning.Bindings
             StandardProvider.AssignProviderCallback(this.BindingConfiguration, this.Binding.Service);
             this.Binding.Target = BindingTarget.Self;
 
-            return new BindingConfigurationBuilder<T1>(this.Binding.BindingConfiguration, this.ServiceNames);
+            return new BindingConfigurationBuilder<T1>(this.Binding.BindingConfiguration, this.BindingRoot, this.ServiceNames);
         }
 
         /// <summary>

--- a/src/Ninject/Planning/Bindings/BindingConfigurationBuilder.cs
+++ b/src/Ninject/Planning/Bindings/BindingConfigurationBuilder.cs
@@ -53,13 +53,19 @@ namespace Ninject.Planning.Bindings
         public IBindingConfiguration BindingConfiguration { get; private set; }
 
         /// <summary>
+        /// Gets the associated binding root.
+        /// </summary>
+        public IBindingRoot BindingRoot { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the BindingBuilder&lt;T&gt; class.
         /// </summary>
         /// <param name="bindingConfiguration">The binding configuration to build.</param>
         /// <param name="serviceNames">The names of the configured services.</param>
-        public BindingConfigurationBuilder(IBindingConfiguration bindingConfiguration, string serviceNames)
+        public BindingConfigurationBuilder(IBindingConfiguration bindingConfiguration, IBindingRoot bindingRoot, string serviceNames)
         {
             this.BindingConfiguration = bindingConfiguration;
+            this.BindingRoot = bindingRoot;
             this.serviceNames = serviceNames;
         }
 

--- a/src/Ninject/ReadonlyKernel.cs
+++ b/src/Ninject/ReadonlyKernel.cs
@@ -327,7 +327,7 @@
         private void AddReadonlyKernelBinding<T>(T readonlyKernel, Multimap<Type, IBinding> bindings)
         {
             var binding = new Binding(typeof(T));
-            new BindingBuilder<T>(binding, this.Settings, typeof(T).Format()).ToConstant(readonlyKernel);
+            new BindingBuilder<T>(binding, null, this.Settings, typeof(T).Format()).ToConstant(readonlyKernel);
             bindings.Add(typeof(T), binding);
         }
 

--- a/src/Ninject/Syntax/BindingRoot.cs
+++ b/src/Ninject/Syntax/BindingRoot.cs
@@ -57,7 +57,7 @@ namespace Ninject.Syntax
             var binding = new Binding(service);
             this.AddBinding(binding);
 
-            return new BindingBuilder<T>(binding, this.Settings, service.Format());
+            return new BindingBuilder<T>(binding, this, this.Settings, service.Format());
 #endif
         }
 
@@ -77,7 +77,7 @@ namespace Ninject.Syntax
             this.AddBinding(new Binding(typeof(T2), firstBinding.BindingConfiguration));
             var serviceNames = new[] { typeof(T1).Format(), typeof(T2).Format() };
 
-            return new BindingBuilder<T1, T2>(firstBinding.BindingConfiguration, this.Settings, string.Join(", ", serviceNames));
+            return new BindingBuilder<T1, T2>(firstBinding.BindingConfiguration, this, this.Settings, string.Join(", ", serviceNames));
 #endif
         }
 
@@ -99,7 +99,7 @@ namespace Ninject.Syntax
             this.AddBinding(new Binding(typeof(T3), firstBinding.BindingConfiguration));
             var serviceNames = new[] { typeof(T1).Format(), typeof(T2).Format(), typeof(T3).Format() };
 
-            return new BindingBuilder<T1, T2, T3>(firstBinding.BindingConfiguration, this.Settings, string.Join(", ", serviceNames));
+            return new BindingBuilder<T1, T2, T3>(firstBinding.BindingConfiguration, this, this.Settings, string.Join(", ", serviceNames));
 #endif
         }
 
@@ -123,7 +123,7 @@ namespace Ninject.Syntax
             this.AddBinding(new Binding(typeof(T4), firstBinding.BindingConfiguration));
             var serviceNames = new[] { typeof(T1).Format(), typeof(T2).Format(), typeof(T3).Format(), typeof(T4).Format() };
 
-            return new BindingBuilder<T1, T2, T3, T4>(firstBinding.BindingConfiguration, this.Settings, string.Join(", ", serviceNames));
+            return new BindingBuilder<T1, T2, T3, T4>(firstBinding.BindingConfiguration, this, this.Settings, string.Join(", ", serviceNames));
 #endif
         }
 
@@ -151,7 +151,7 @@ namespace Ninject.Syntax
                 this.AddBinding(new Binding(service, firstBinding.BindingConfiguration));                
             }
 
-            return new BindingBuilder<object>(firstBinding, this.Settings, string.Join(", ", services.Select(service => service.Format()).ToArray()));
+            return new BindingBuilder<object>(firstBinding, this, this.Settings, string.Join(", ", services.Select(service => service.Format()).ToArray()));
 #endif
         }
 

--- a/src/Ninject/Syntax/IBindingSyntax.cs
+++ b/src/Ninject/Syntax/IBindingSyntax.cs
@@ -28,7 +28,7 @@ namespace Ninject.Syntax
     /// <summary>
     /// Used to define a basic binding syntax builder.
     /// </summary>
-    public interface IBindingSyntax : IHaveBindingConfiguration, IFluentSyntax
+    public interface IBindingSyntax : IHaveBindingConfiguration, IHaveBindingRoot, IFluentSyntax
     {
     }
 }


### PR DESCRIPTION
... to make IBindingRoot available in fluent API extensions

Currently it is not possible to access the IBindingRoot to add additional bindings when extending the fluent API (as done by extensions like Ninject.Extensions.Factory).

This was changed during the readonly kernel refactoring (before it was accessible by the Kernel property)
