### PR TITLE
Added strongly typed overloads of WithConstructorArgument which use callback to get the value

### DIFF
--- a/src/Ninject/Planning/Bindings/BindingConfigurationBuilder.cs
+++ b/src/Ninject/Planning/Bindings/BindingConfigurationBuilder.cs
@@ -525,6 +525,11 @@ namespace Ninject.Planning.Bindings
             return this.WithConstructorArgument(type, (context, target) => callback(context));
         }
 
+        public IBindingWithOrOnSyntax<T> WithConstructorArgument<TValue>(Func<IContext, TValue> callback)
+        {
+            return this.WithConstructorArgument(typeof(TValue), (context, target) => callback(context));
+        }
+
         /// <summary>
         /// Indicates that the specified constructor argument should be overridden with the specified value.
         /// </summary>
@@ -534,6 +539,12 @@ namespace Ninject.Planning.Bindings
         public IBindingWithOrOnSyntax<T> WithConstructorArgument(Type type, Func<IContext, ITarget, object> callback)
         {
             this.BindingConfiguration.Parameters.Add(new TypeMatchingConstructorArgument(type, callback));
+            return this;
+        }
+
+        public IBindingWithOrOnSyntax<T> WithConstructorArgument<TValue>(Func<IContext, ITarget, TValue> callback)
+        {
+            this.WithConstructorArgument(typeof (TValue), callback);
             return this;
         }
 

--- a/src/Ninject/Syntax/IBindingWithSyntax.cs
+++ b/src/Ninject/Syntax/IBindingWithSyntax.cs
@@ -86,10 +86,26 @@ namespace Ninject.Syntax
         /// <summary>
         /// Indicates that the specified constructor argument should be overridden with the specified value.
         /// </summary>
+        /// <typeparam name="TValue">Specifies the argument type to override.</typeparam>
+        /// <param name="callback">The callback to invoke to get the value for the argument.</param>
+        /// <returns>The fluent syntax.</returns>
+        IBindingWithOrOnSyntax<T> WithConstructorArgument<TValue>(Func<IContext, TValue> callback);
+
+        /// <summary>
+        /// Indicates that the specified constructor argument should be overridden with the specified value.
+        /// </summary>
         /// <param name="type">The type of the argument to override.</param>
         /// <param name="callback">The callback to invoke to get the value for the argument.</param>    
         /// <returns>The fluent syntax.</returns>
         IBindingWithOrOnSyntax<T> WithConstructorArgument(Type type, Func<IContext, ITarget, object> callback);
+
+        /// <summary>
+        /// Indicates that the specified constructor argument should be overridden with the specified value.
+        /// </summary>
+        /// <typeparam name="TValue">Specifies the argument type to override.</typeparam>
+        /// <param name="callback">The callback to invoke to get the value for the argument.</param>    
+        /// <returns>The fluent syntax.</returns>
+        IBindingWithOrOnSyntax<T> WithConstructorArgument<TValue>(Func<IContext, ITarget, TValue> callback);
 
         /// <summary>
         /// Indicates that the specified property should be injected with the specified value.


### PR DESCRIPTION
I Added strongly typed overloads of WithConstructorArgument which use a callback to get the value so that you do not need to pass the type of the argument any more. This also guarantees that the callback you pass returns the type that you specified as a generic argument.