### PR TITLE
Do not choose constructors with an "Obsolete" attribute

### DIFF
--- a/src/Ninject.Test/Integration/ConstructorSelectionTests.cs
+++ b/src/Ninject.Test/Integration/ConstructorSelectionTests.cs
@@ -222,6 +222,18 @@ namespace Ninject.Tests.Integration
             instance.Generic.Should().NotBeNull();
         }
 
+        [Fact]
+        public void DoNotChooseObsoleteConstructors()
+        {
+            kernel.Bind<ClassWithObsoleteContructor>().ToSelf();
+
+            var instance = kernel.Get<ClassWithObsoleteContructor>();
+
+            instance.Should().NotBeNull();
+            instance.SomeObject.Should().NotBeNull();
+            instance.ObsoleteConstructorCalled.Should().Be(false);
+        }
+
 #if !SILVERLIGHT
         [Fact]
         public void WhenConstructorHasAValueWithDefaultValueItCountsAsServedParameter()
@@ -285,6 +297,24 @@ namespace Ninject.Tests.Integration
             public ClassWithTwoInjectAttributes(int someValue)
             {
             }
+        }
+
+        public class ClassWithObsoleteContructor
+        {
+            [Obsolete("Use Ninject to create an instance")]
+            public ClassWithObsoleteContructor()
+                : this(new object())
+            {
+                ObsoleteConstructorCalled = true;
+            }
+
+            public ClassWithObsoleteContructor(Object someObject)
+            {
+                SomeObject = someObject;
+            }
+
+            public Object SomeObject { get; set; }
+            public bool ObsoleteConstructorCalled { get; set; }
         }
     }
 }

--- a/src/Ninject/INinjectSettings.cs
+++ b/src/Ninject/INinjectSettings.cs
@@ -37,6 +37,11 @@ namespace Ninject
         Type InjectAttribute { get; }
 
         /// <summary>
+        /// Gets the attribute that indicates that a member is obsolete and should not be injected.
+        /// </summary>
+        Type ObsoleteAttribute { get; }
+
+        /// <summary>
         /// Gets the interval at which the cache should be pruned.
         /// </summary>
         TimeSpan CachePruningInterval { get; }

--- a/src/Ninject/NinjectSettings.cs
+++ b/src/Ninject/NinjectSettings.cs
@@ -65,6 +65,15 @@ namespace Ninject
         }
 
         /// <summary>
+        /// Gets or sets the attribute that indicates that a member is obsolete and should not be injected.
+        /// </summary>
+        public Type ObsoleteAttribute
+        {
+            get { return this.Get("ObsoleteAttribute", typeof(ObsoleteAttribute)); }
+            set { this.Set("ObsoleteAttribute", value); }
+        }
+
+        /// <summary>
         /// Gets or sets the interval at which the GC should be polled.
         /// </summary>
         public TimeSpan CachePruningInterval

--- a/src/Ninject/Planning/Directives/ConstructorInjectionDirective.cs
+++ b/src/Ninject/Planning/Directives/ConstructorInjectionDirective.cs
@@ -51,5 +51,11 @@ namespace Ninject.Planning.Directives
         /// </summary>
         /// <value><c>true</c> if this constructor has an inject attribute; otherwise, <c>false</c>.</value>
         public bool HasInjectAttribute { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this constructor has an Obsolete attribute.
+        /// </summary>
+        /// <value><c>true</c> if this constructor has an Obsolete attribute; otherwise, <c>false</c>.</value>
+        public bool HasObsoleteAttribute { get; set; }
     }
 }

--- a/src/Ninject/Planning/Strategies/ConstructorReflectionStrategy.cs
+++ b/src/Ninject/Planning/Strategies/ConstructorReflectionStrategy.cs
@@ -72,9 +72,11 @@ namespace Ninject.Planning.Strategies
             foreach (ConstructorInfo constructor in constructors)
             {
                 var hasInjectAttribute = constructor.HasAttribute(this.Settings.InjectAttribute);
+                var hasObsoleteAttribute = constructor.HasAttribute(this.Settings.ObsoleteAttribute);
                 var directive = new ConstructorInjectionDirective(constructor, this.InjectorFactory.Create(constructor))
                 {
-                     HasInjectAttribute = hasInjectAttribute
+                    HasInjectAttribute = hasInjectAttribute,
+                    HasObsoleteAttribute = hasObsoleteAttribute
                 };
 
                 plan.Add(directive);

--- a/src/Ninject/Selection/Heuristics/StandardConstructorScorer.cs
+++ b/src/Ninject/Selection/Heuristics/StandardConstructorScorer.cs
@@ -57,6 +57,11 @@ namespace Ninject.Selection.Heuristics
                 return int.MaxValue;
             }
 
+            if (directive.HasObsoleteAttribute)
+            {
+                return int.MinValue;
+            }
+
             var score = 1;
             foreach (ITarget target in directive.Targets)
             {


### PR DESCRIPTION
This heavily discourages Ninject from choosing constructors that are marked obsolete. I'm willing to bet that when Ninject chooses an obsolete constructor it was an unintentional mistake, and can go unnoticed.

I've replicated our specific mistake in the unit test, but there are multiple other scenarios. In our scenario an implicit binding can be created and used, but in the general case we'd rather have Ninject fail instead of using the obsolete constructor.
