### PR TITLE
Add assemblyinfo with CLSCompliant(true)

### DIFF
--- a/src/Ninject/Properties/AssemblyInfo.cs
+++ b/src/Ninject/Properties/AssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2007-2010, Enkari, Ltd.
+//   Copyright (c) 2010-2017, Ninject Project Contributors
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+using System;
+
+[assembly: CLSCompliant(true)]


### PR DESCRIPTION
Ninject is no longer marked as CLS compliant where it once was. This PR reintroduces an assemblyinfo file with the CLSCompliant attribute marked true.