### PR TITLE
Expose internals of Ninject to Ninject.Test

### DIFF
--- a/src/Ninject.Test/Ninject.Test.csproj
+++ b/src/Ninject.Test/Ninject.Test.csproj
@@ -7,7 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Ninject.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Update="TestModules\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Ninject.Test/Ninject.Test.csproj
+++ b/src/Ninject.Test/Ninject.Test.csproj
@@ -3,18 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <Optimize>true</Optimize>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Ninject.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
   </PropertyGroup>
   
   <ItemGroup>
@@ -41,12 +32,6 @@
   <ItemGroup>
     <ProjectReference Include="..\TestAssembly\TestAssembly.csproj" />
     <ProjectReference Include="..\TestModules\TestModules.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System">
-      <HintPath>System</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/src/Ninject.Test/Ninject.Test.csproj
+++ b/src/Ninject.Test/Ninject.Test.csproj
@@ -3,9 +3,20 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <Optimize>true</Optimize>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\Ninject.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Update="TestModules\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -30,6 +41,12 @@
   <ItemGroup>
     <ProjectReference Include="..\TestAssembly\TestAssembly.csproj" />
     <ProjectReference Include="..\TestModules\TestModules.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System">
+      <HintPath>System</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/src/Ninject/Properties/AssemblyInfo.cs
+++ b/src/Ninject/Properties/AssemblyInfo.cs
@@ -20,5 +20,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(true)]
+[assembly: InternalsVisibleTo("Ninject.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f3fc252fdcdfdba2e6d41c88aa5d644aa480c3776f4d7a3f02625347a53fef16b3940741285b67067480cc1eda51f1a9b255cc3af2dcf77325621bd9f644de9e1311a5d2f8bd3054573da970c33566033d91c0fe4420d5b01f996a32ae3a44fad49974edb8546f418eca586ea085a1a175a1b79d6ec84f75d4b814a40b2abcb9")]


### PR DESCRIPTION
Expose internals of **Ninject** to **Ninject.Test** to allows us to test internals.
Strongname **Ninject.Test**, and only optimize code in **Release** configuration (to allow us to debug tests).