### PR TITLE
Improve performance and reduce allocations in Plan.

### DIFF
--- a/src/Ninject.Test/Unit/Planning/PlanTests.cs
+++ b/src/Ninject.Test/Unit/Planning/PlanTests.cs
@@ -1,0 +1,144 @@
+﻿using Ninject.Planning;
+using Ninject.Planning.Directives;
+using System;
+using Xunit;
+
+namespace Ninject.Test.Unit.Planning
+{
+    public class PlanTests
+    {
+        private Plan _plan;
+        private ConstructorInjectionDirective _constructor1;
+        private ConstructorInjectionDirective _constructor2;
+        private PropertyInjectionDirective _property;
+
+        public PlanTests()
+        {
+            _constructor1 = CreateConstructorInjectionDirective();
+            _constructor2 = CreateConstructorInjectionDirective();
+            _property = CreatePropertyInjectionDirective();
+
+            _plan = new Plan(this.GetType());
+            _plan.Add(_constructor1);
+            _plan.Add(_property);
+            _plan.Add(_constructor2);
+        }
+
+        [Fact]
+        public void Ctor_Type_ShouldThrowArgumentNullExceptionWhenTypeIsNull()
+        {
+            const Type type = null;
+
+            var actualException = Assert.Throws<ArgumentNullException>(() => new Plan(type));
+            Assert.Equal(nameof(type), actualException.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_Type()
+        {
+            var plan = new Plan(typeof(MyService));
+
+            Assert.Same(typeof(MyService), plan.Type);
+            Assert.Empty(plan.Directives);
+        }
+
+        [Fact]
+        public void Add_Directive_ShouldThrowArgumentNullExceptionWhenDirectiveIsNull()
+        {
+            const IDirective directive = null;
+
+            var actualException = Assert.Throws<ArgumentNullException>(() => _plan.Add(directive));
+            Assert.Equal(nameof(directive), actualException.ParamName);
+        }
+
+        [Fact]
+        public void Has_ShouldReturnFalseWhenNoDirectiveOfSpecifiedTypeExists()
+        {
+            Assert.False(_plan.Has<MethodInjectionDirective>());
+        }
+
+        [Fact]
+        public void Has_ShouldReturnTrueWhenAtLeastOneDirectiveOfSpecifiedTypeExists()
+        {
+            Assert.True(_plan.Has<ConstructorInjectionDirective>());
+            Assert.True(_plan.Has<PropertyInjectionDirective>());
+        }
+
+        [Fact]
+        public void GetOne_ShouldReturnDirectiveOfSpecifiedTypeWhenOnlyOneDirectiveOfSpecifiedTypeExists()
+        {
+            var actual = _plan.GetOne<PropertyInjectionDirective>();
+
+            Assert.NotNull(actual);
+            Assert.Same(_property, actual);
+        }
+
+        [Fact]
+        public void GetOne_ShouldReturnNullWhenNoDirectiveOfSpecifiedTypeExists()
+        {
+            Assert.Null(_plan.GetOne<MethodInjectionDirective>());
+        }
+
+        [Fact]
+        public void GetOne_ShoulThrowInvalidOperationExceptionWhenMoreThanOneDirectiveOfSpecifiedTypeExists()
+        {
+            Assert.Throws<InvalidOperationException>(() => _plan.GetOne<ConstructorInjectionDirective>());
+        }
+
+        [Fact]
+        public void GetOne_ShouldReturnAllDirectivesOfSpecifiedType()
+        {
+            var actual = _plan.GetAll<ConstructorInjectionDirective>();
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(_constructor1, enumerator.Current);
+
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(_constructor2, enumerator.Current);
+
+                Assert.False(enumerator.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void GetAll_ShouldReturnEmptyEnumeratorWhenNoDirectivesOfSpecifiedTypeExist()
+        {
+            var actual = _plan.GetAll<MethodInjectionDirective>();
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.False(enumerator.MoveNext());
+            }
+        }
+
+        private static ConstructorInjectionDirective CreateConstructorInjectionDirective()
+        {
+            return new ConstructorInjectionDirective(typeof(MyService).GetConstructor(new Type[0]), (_) => null);
+        }
+
+        private static PropertyInjectionDirective CreatePropertyInjectionDirective()
+        {
+            return new PropertyInjectionDirective(typeof(MyService).GetProperty("Name"), (target, value) => { });
+        }
+
+        private static MethodInjectionDirective CreateMethodInjectionDirective()
+        {
+            return new MethodInjectionDirective(typeof(MyService).GetMethod("Run"), (target, arguments) => { });
+        }
+
+        public class MyService
+        {
+            public MyService()
+            {
+            }
+
+            public string Name { get; }
+
+            public void Run()
+            {
+            }
+        }
+    }
+}

--- a/src/Ninject/Planning/Plan.cs
+++ b/src/Ninject/Planning/Plan.cs
@@ -96,7 +96,13 @@ namespace Ninject.Planning
         public IEnumerable<TDirective> GetAll<TDirective>()
             where TDirective : IDirective
         {
-            return this.Directives.OfType<TDirective>();
+            foreach (var directive in this.Directives)
+            {
+                if (directive is TDirective tdir)
+                {
+                    yield return tdir;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
* Improves performance and reduces allocations in Plan.
* Add unit tests for Plan.

**Before:**

|                    Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------- |----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|  HasDirective_Match_First |  77.12 ns | 0.9070 ns | 0.8484 ns |      0.0228 |           - |           - |                96 B |
| HasDirective_Match_Middle | 169.68 ns | 1.1336 ns | 1.0603 ns |      0.0226 |           - |           - |                96 B |
|   HasDirective_Match_Last | 240.03 ns | 0.8890 ns | 0.7881 ns |      0.0224 |           - |           - |                96 B |
|      HasDirective_NoMatch | 256.20 ns | 1.8254 ns | 1.7075 ns |      0.0224 |           - |           - |                96 B |
|        GetOne_Match_First | 277.86 ns | 1.1517 ns | 1.0773 ns |      0.0224 |           - |           - |                96 B |
|       GetOne_Match_Middle | 281.71 ns | 1.6616 ns | 1.4730 ns |      0.0224 |           - |           - |                96 B |
|         GetOne_Match_Last | 266.67 ns | 2.2552 ns | 2.1095 ns |      0.0224 |           - |           - |                96 B |
|            GetOne_NoMatch | 260.81 ns | 1.4024 ns | 1.3118 ns |      0.0224 |           - |           - |                96 B |
|              GetAll_Match |  25.47 ns | 0.2412 ns | 0.2256 ns |      0.0133 |           - |           - |                56 B |
|            GetAll_NoMatch |  25.98 ns | 0.3688 ns | 0.3450 ns |      0.0133 |           - |           - |                56 B |


**After:**

|                    Method |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------- |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|  HasDirective_Match_First |  39.620 ns | 0.2334 ns | 0.2069 ns |      0.0209 |           - |           - |                88 B |
| HasDirective_Match_Middle | 121.500 ns | 1.5366 ns | 1.3622 ns |      0.0207 |           - |           - |                88 B |
|   HasDirective_Match_Last | 189.981 ns | 0.7099 ns | 0.6640 ns |      0.0207 |           - |           - |                88 B |
|      HasDirective_NoMatch | 209.746 ns | 2.0663 ns | 1.9329 ns |      0.0207 |           - |           - |                88 B |
|        GetOne_Match_First | 226.161 ns | 1.0210 ns | 0.8526 ns |      0.0207 |           - |           - |                88 B |
|       GetOne_Match_Middle | 226.589 ns | 0.6180 ns | 0.5781 ns |      0.0207 |           - |           - |                88 B |
|         GetOne_Match_Last | 218.492 ns | 2.5944 ns | 2.4268 ns |      0.0207 |           - |           - |                88 B |
|            GetOne_NoMatch | 219.027 ns | 0.7464 ns | 0.6982 ns |      0.0207 |           - |           - |                88 B |
|              GetAll_Match |   5.787 ns | 0.0383 ns | 0.0358 ns |      0.0114 |           - |           - |                48 B |
|            GetAll_NoMatch |   5.788 ns | 0.0583 ns | 0.0545 ns |      0.0114 |           - |           - |                48 B |

