### PR TITLE
Improve performance and reduce allocations in Pipeline

### DIFF
--- a/src/Ninject.Benchmarks/Activation/PipelineBenchmark.cs
+++ b/src/Ninject.Benchmarks/Activation/PipelineBenchmark.cs
@@ -1,0 +1,115 @@
+﻿using BenchmarkDotNet.Attributes;
+using Moq;
+using Ninject.Activation;
+using Ninject.Activation.Caching;
+using Ninject.Activation.Strategies;
+using System.Collections.Generic;
+
+namespace Ninject.Benchmarks.Activation
+{
+    [MemoryDiagnoser]
+    public class PipelineBenchmark
+    {
+        private Pipeline _pipelineWithoutStrategies;
+        private Pipeline _pipelineWithStrategies;
+        private InstanceReference _activatedReference;
+        private InstanceReference _deactivatedReference;
+        private IContext _context;
+
+        public PipelineBenchmark()
+        {
+            var cachePruner = new GarbageCollectionCachePruner(new NinjectSettings());
+            var activationCache = new ActivationCache(cachePruner);
+
+            for (var i = 0; i < 1000; i++)
+            {
+                activationCache.AddActivatedInstance("" + i);
+                activationCache.AddDeactivatedInstance("" + i);
+            }
+
+            var noStrategies = new List<IActivationStrategy>();
+            _pipelineWithoutStrategies = new Pipeline(noStrategies, activationCache);
+
+            var strategies = new List<IActivationStrategy> {
+                                                            new NoOpStrategy(),
+                                                            new NoOpStrategy(),
+                                                            new NoOpStrategy(),
+                                                            new NoOpStrategy(),
+                                                            new NoOpStrategy(),
+                                                            new NoOpStrategy()
+                                                           };
+            _pipelineWithStrategies = new Pipeline(strategies, activationCache);
+
+            _activatedReference = new InstanceReference { Instance = "ACTIVATED" };
+            activationCache.AddActivatedInstance(_activatedReference.Instance);
+
+            _deactivatedReference = new InstanceReference { Instance = "DEACTIVATED" };
+            activationCache.AddDeactivatedInstance(_deactivatedReference.Instance);
+
+            _context = new Mock<IContext>(MockBehavior.Strict).Object;
+        }
+
+        [Benchmark]
+        public void Activate_WithStrategies_ObjectActivated()
+        {
+            _pipelineWithStrategies.Activate(_context, _activatedReference);
+        }
+
+        [Benchmark]
+        public void Activate_WithStrategies_ObjectNotActivated()
+        {
+            _pipelineWithStrategies.Activate(_context, _deactivatedReference);
+        }
+
+        [Benchmark]
+        public void Activate_WithoutStrategies_ObjectActivated()
+        {
+            _pipelineWithoutStrategies.Activate(_context, _activatedReference);
+        }
+
+        [Benchmark]
+        public void Activate_WithoutStrategies_ObjectNotActivated()
+        {
+            _pipelineWithoutStrategies.Activate(_context, _deactivatedReference);
+        }
+
+        [Benchmark]
+        public void Deactivate_WithStrategies_ObjectDeactivated()
+        {
+            _pipelineWithStrategies.Deactivate(_context, _deactivatedReference);
+        }
+
+        [Benchmark]
+        public void Deactivate_WithStrategies_ObjectNotDeactivated()
+        {
+            _pipelineWithStrategies.Deactivate(_context, _activatedReference);
+        }
+
+        [Benchmark]
+        public void Deactivate_WithoutStrategies_ObjectDeactivated()
+        {
+            _pipelineWithoutStrategies.Deactivate(_context, _deactivatedReference);
+        }
+
+        [Benchmark]
+        public void Deactivate_WithoutStrategies_ObjectNotDeactivated()
+        {
+            _pipelineWithoutStrategies.Deactivate(_context, _activatedReference);
+        }
+
+        public class NoOpStrategy : IActivationStrategy
+        {
+            public void Activate(IContext context, InstanceReference reference)
+            {
+            }
+
+            public void Deactivate(IContext context, InstanceReference reference)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Ninject/Activation/Pipeline.cs
+++ b/src/Ninject/Activation/Pipeline.cs
@@ -28,7 +28,6 @@ namespace Ninject.Activation
     using Ninject.Activation.Strategies;
     using Ninject.Components;
     using Ninject.Infrastructure;
-    using Ninject.Infrastructure.Language;
 
     /// <summary>
     /// Drives the activation (injection, etc.) of an instance.
@@ -41,6 +40,11 @@ namespace Ninject.Activation
         private readonly IActivationCache activationCache;
 
         /// <summary>
+        /// The strategies that contribute to the activation and deactivation processes.
+        /// </summary>
+        private readonly List<IActivationStrategy> strategies;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Pipeline"/> class.
         /// </summary>
         /// <param name="strategies">The strategies to execute during activation and deactivation.</param>
@@ -50,14 +54,17 @@ namespace Ninject.Activation
             Ensure.ArgumentNotNull(strategies, "strategies");
             Ensure.ArgumentNotNull(activationCache, "activationCache");
 
-            this.Strategies = strategies.ToList();
+            this.strategies = strategies.ToList();
             this.activationCache = activationCache;
         }
 
         /// <summary>
         /// Gets the strategies that contribute to the activation and deactivation processes.
         /// </summary>
-        public IList<IActivationStrategy> Strategies { get; private set; }
+        public IList<IActivationStrategy> Strategies
+        {
+            get { return this.strategies; }
+        }
 
         /// <summary>
         /// Activates the instance in the specified context.
@@ -71,7 +78,7 @@ namespace Ninject.Activation
 
             if (!this.activationCache.IsActivated(reference.Instance))
             {
-                this.Strategies.Map(s => s.Activate(context, reference));
+                this.strategies.ForEach(s => s.Activate(context, reference));
             }
         }
 
@@ -87,7 +94,7 @@ namespace Ninject.Activation
 
             if (!this.activationCache.IsDeactivated(reference.Instance))
             {
-                this.Strategies.Map(s => s.Deactivate(context, reference));
+                this.strategies.ForEach(s => s.Deactivate(context, reference));
             }
         }
     }


### PR DESCRIPTION
Improves performance and reduce allocationss in **Pipeline** by avoiding virtual method calls and using `List<T>.ForEach(Action<T> action)` instead of `ExtensionsForIEnumerableOfT.Map(this IEnumerable<T> series, Action<T> action)` extension method.

**Before:**

|                                            Method |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------------------------------- |----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|           Activate_WithStrategies_ObjectActivated |  34.86 ns | 0.0287 ns | 0.0240 ns |      0.0076 |           - |           - |                32 B |
|        Activate_WithStrategies_ObjectNotActivated | 107.14 ns | 0.0966 ns | 0.0856 ns |      0.0323 |           - |           - |               136 B |
|        Activate_WithoutStrategies_ObjectActivated |  33.83 ns | 0.0296 ns | 0.0277 ns |      0.0076 |           - |           - |                32 B |
|     Activate_WithoutStrategies_ObjectNotActivated |  38.20 ns | 0.0277 ns | 0.0260 ns |      0.0324 |           - |           - |               136 B |
|       Deactivate_WithStrategies_ObjectDeactivated |  36.93 ns | 0.0492 ns | 0.0460 ns |      0.0076 |           - |           - |                32 B |
|    Deactivate_WithStrategies_ObjectNotDeactivated | 107.65 ns | 0.4853 ns | 0.4302 ns |      0.0323 |           - |           - |               136 B |
|    Deactivate_WithoutStrategies_ObjectDeactivated |  36.69 ns | 0.0232 ns | 0.0217 ns |      0.0076 |           - |           - |                32 B |
| Deactivate_WithoutStrategies_ObjectNotDeactivated |  38.12 ns | 0.0428 ns | 0.0401 ns |      0.0324 |           - |           - |               136 B |

**After:**

|                                            Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------------------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|           Activate_WithStrategies_ObjectActivated | 34.80 ns | 0.0247 ns | 0.0231 ns |      0.0076 |           - |           - |                32 B |
|        Activate_WithStrategies_ObjectNotActivated | 41.44 ns | 0.0931 ns | 0.0871 ns |      0.0228 |           - |           - |                96 B |
|        Activate_WithoutStrategies_ObjectActivated | 33.76 ns | 0.0251 ns | 0.0222 ns |      0.0076 |           - |           - |                32 B |
|     Activate_WithoutStrategies_ObjectNotActivated | 27.64 ns | 0.0716 ns | 0.0634 ns |      0.0229 |           - |           - |                96 B |
|       Deactivate_WithStrategies_ObjectDeactivated | 36.89 ns | 0.0923 ns | 0.0863 ns |      0.0076 |           - |           - |                32 B |
|    Deactivate_WithStrategies_ObjectNotDeactivated | 41.75 ns | 0.1960 ns | 0.1737 ns |      0.0228 |           - |           - |                96 B |
|    Deactivate_WithoutStrategies_ObjectDeactivated | 37.18 ns | 0.0817 ns | 0.0764 ns |      0.0076 |           - |           - |                32 B |
| Deactivate_WithoutStrategies_ObjectNotDeactivated | 27.32 ns | 0.1722 ns | 0.1526 ns |      0.0229 |           - |           - |                96 B |
