### PR TITLE
Improve performance and parallelism, and reduce allocations in Planner

### DIFF
--- a/src/Ninject.Benchmarks/Planning/PlannerBenchmark.cs
+++ b/src/Ninject.Benchmarks/Planning/PlannerBenchmark.cs
@@ -1,0 +1,181 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ninject.Planning;
+using Ninject.Planning.Strategies;
+using Ninject.Tests.Fakes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ninject.Benchmarks.Planning
+{
+    [MemoryDiagnoser]
+    public class PlannerBenchmark
+    {
+        private const int MaxTypeCount = 1_800;
+        private static readonly TimeSpan StrategyExecuteDelay = TimeSpan.FromMilliseconds(0.2);
+
+        private List<IPlanningStrategy> _strategiesWithDelay;
+        private List<IPlanningStrategy> _strategiesWithoutDelay;
+        private Planner _plannerWithDelay;
+        private Planner _plannerWithoutDelay;
+        private Type[] _types;
+
+        public PlannerBenchmark()
+        {
+            _strategiesWithDelay = new List<IPlanningStrategy>
+                {
+                    new DelayPlanningStrategy(),
+                    new DelayPlanningStrategy(),
+                    new DelayPlanningStrategy(),
+                    new DelayPlanningStrategy()
+                };
+            _strategiesWithoutDelay = new List<IPlanningStrategy>
+                {
+                    new NoOpPlanningStrategy(),
+                    new NoOpPlanningStrategy(),
+                    new NoOpPlanningStrategy(),
+                    new NoOpPlanningStrategy()
+                };
+            _types = typeof(string).Assembly.GetTypes();
+
+            if (_types.Length < 1_800)
+                throw new Exception($"Expected min. {MaxTypeCount} types in {typeof(string).Assembly.FullName}, but was {_types.Length}.");
+        }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _plannerWithDelay = new Planner(_strategiesWithDelay);
+            _plannerWithDelay.GetPlan(typeof(Monk));
+
+            _plannerWithoutDelay = new Planner(_strategiesWithoutDelay);
+        }
+
+        [Benchmark]
+        public void GetPlan_Existing_Serial()
+        {
+            _plannerWithDelay.GetPlan(typeof(Monk));
+        }
+
+        [Benchmark(OperationsPerInvoke = 25_000)]
+        public void GetPlan_Existing_Parallel()
+        {
+            const int threads = 25;
+            const int iterationsPerThread = 1000;
+            var type = GetType();
+
+            var tasks = Enumerable.Range(1, threads).Select((_) =>
+            {
+                return Task.Factory.StartNew(() =>
+                {
+                    for (var i = 0; i < iterationsPerThread; i++)
+                    {
+                        _plannerWithDelay.GetPlan(type);
+                    }
+                });
+            });
+
+            Task.WaitAll(tasks.ToArray());
+        }
+
+        [Benchmark(OperationsPerInvoke = MaxTypeCount)]
+        public void GetPlan_New_WithDelay_Serial()
+        {
+            for (var i = 0; i < MaxTypeCount; i++)
+            {
+                _plannerWithDelay.GetPlan(_types[i]);
+            }
+
+            _plannerWithDelay = new Planner(_strategiesWithDelay);
+        }
+
+        [Benchmark(OperationsPerInvoke = MaxTypeCount)]
+        public void GetPlan_New_WithoutDelay_Serial()
+        {
+            for (var i = 0; i < MaxTypeCount; i++)
+            {
+                _plannerWithDelay.GetPlan(_types[i]);
+            }
+
+            _plannerWithoutDelay = new Planner(_strategiesWithoutDelay);
+        }
+
+        [Benchmark(OperationsPerInvoke = MaxTypeCount)]
+        public void GetPlan_New_WithDelay_Parallel()
+        {
+            const int threadCount = 36;
+            const int iterationsPerThread = 50;
+
+            var tasks = Enumerable.Range(1, threadCount).Select((i) =>
+            {
+                return Task.Factory.StartNew(() =>
+                {
+                    // Each thread gets its unique range of types.
+                    var typeIndex = i * iterationsPerThread;
+                    var typeEndIndex = typeIndex + iterationsPerThread;
+
+                    while (typeIndex < typeEndIndex)
+                    {
+                        _plannerWithDelay.GetPlan(_types[typeIndex++]);
+                    }
+                });
+            });
+
+            Task.WaitAll(tasks.ToArray());
+
+            // create new planner to ensure next exection of method again creates new plans
+            _plannerWithDelay = new Planner(_strategiesWithDelay);
+        }
+
+        [Benchmark(OperationsPerInvoke = MaxTypeCount)]
+        public void GetPlan_New_WithoutDelay_Parallel()
+        {
+            const int threadCount = 36;
+            const int iterationsPerThread = 50;
+
+            var tasks = Enumerable.Range(1, threadCount).Select((i) =>
+            {
+                return Task.Factory.StartNew(() =>
+                {
+                    // Each thread gets its unique range of types.
+                    var typeIndex = i * iterationsPerThread;
+                    var typeEndIndex = typeIndex + iterationsPerThread;
+
+                    while (typeIndex < typeEndIndex)
+                    {
+                        _plannerWithoutDelay.GetPlan(_types[typeIndex++]);
+                    }
+                });
+            });
+
+            Task.WaitAll(tasks.ToArray());
+
+            // create new planner to ensure next exection of method again creates new plans
+            _plannerWithoutDelay = new Planner(_strategiesWithoutDelay);
+        }
+
+        public class DelayPlanningStrategy : IPlanningStrategy
+        {
+            public void Execute(IPlan plan)
+            {
+                Task.Delay(StrategyExecuteDelay);
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+
+        public class NoOpPlanningStrategy : IPlanningStrategy
+        {
+            public void Execute(IPlan plan)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Ninject.Test/Unit/Planning/PlannerTests.cs
+++ b/src/Ninject.Test/Unit/Planning/PlannerTests.cs
@@ -1,0 +1,172 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ConstructorArgumentInBindingConfigurationBuilderTest.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2013 Ninject Project Contributors
+//   Authors: Ivan Appert (iappert@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Ninject.Planning;
+using Ninject.Planning.Strategies;
+using Xunit;
+
+namespace Ninject.Test.Unit.Planning
+{
+    public class PlannerTests
+    {
+        private Mock<IPlanningStrategy> _strategyOneMock;
+        private Mock<IPlanningStrategy> _strategyTwoMock;
+        private IEnumerable<IPlanningStrategy> _strategies;
+        private Planner _target;
+
+        public PlannerTests()
+        {
+            _strategyOneMock = new Mock<IPlanningStrategy>(MockBehavior.Loose);
+            _strategyTwoMock = new Mock<IPlanningStrategy>(MockBehavior.Loose);
+
+            _strategies = new List<IPlanningStrategy>
+                {
+                    _strategyOneMock.Object,
+                    _strategyTwoMock.Object,
+                };
+            _target = new Planner(_strategies);
+        }
+
+        [Fact]
+        public void Ctor_ShouldThrowArgumentNullExceptionWhenStrategiesIsNull()
+        {
+            IEnumerable<IPlanningStrategy> strategies = null;
+
+            var actualException = Assert.Throws<ArgumentNullException>(() => new Planner(strategies));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(strategies), actualException.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_ShouldCloneStrategies()
+        {
+            var actualStrategies = _target.Strategies;
+
+            Assert.NotNull(actualStrategies);
+            Assert.Equal(_strategies, actualStrategies);
+            Assert.NotSame(_strategies, actualStrategies);
+        }
+
+        [Fact]
+        public void GetPlan_ShouldThrowArgumentNullExceptionWhenTypeIsNull()
+        {
+            const Type type = null;
+
+            var actualException = Assert.Throws<ArgumentNullException>(() => _target.GetPlan(type));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(type), actualException.ParamName);
+        }
+
+        /// <summary>
+        /// We do not use a factory to create plans, so we can only verify whether a plan for a given type is created only
+        /// once by checking whether the strategies have only been executed once for a plan.
+        /// </summary>
+        [Fact]
+        public void GetPlan_ShouldCreatePlanOnceForTypeWhenNoPlanExistsForType()
+        {
+            const int threads = 25;
+            const int iterationsPerThread = 50;
+            var type = GetType();
+            var startSignaled = new ManualResetEvent(false);
+
+            var tasks = Enumerable.Range(1, threads).Select((_) =>
+                {
+                    // Wait for signal; this is done to increase likelyhood that more than one thread will
+                    // attempt to create the signal concurrently
+                    startSignaled.WaitOne();
+
+                    return Task.Factory.StartNew(() =>
+                        {
+                            for (var i = 0; i < iterationsPerThread; i++)
+                            {
+                                _target.GetPlan(type);
+                            }
+                        });
+                });
+
+            startSignaled.Set();
+            Task.WaitAll(tasks.ToArray());
+
+            var actualPlan = _target.GetPlan(type);
+
+            Assert.NotNull(actualPlan);
+            Assert.Same(type, actualPlan.Type);
+            Assert.Same(actualPlan, _target.GetPlan(type));
+
+            _strategyOneMock.Verify(p => p.Execute(It.IsAny<Plan>()), Times.Once());
+            _strategyOneMock.Verify(p => p.Execute(It.Is<Plan>((plan) => ReferenceEquals(plan, actualPlan))), Times.Once());
+            _strategyTwoMock.Verify(p => p.Execute(It.IsAny<Plan>()), Times.Once());
+            _strategyTwoMock.Verify(p => p.Execute(It.Is<Plan>((plan) => ReferenceEquals(plan, actualPlan))), Times.Once());
+        }
+
+        [Fact]
+        public void GetPlan_ShouldCreatePlanForEachType()
+        {
+            var typeString = typeof(string);
+            var typeInt32 = typeof(int);
+
+            var planString = _target.GetPlan(typeString);
+
+            _strategyOneMock.Verify(p => p.Execute(It.Is<Plan>((plan) => ReferenceEquals(plan, planString))), Times.Once());
+            _strategyTwoMock.Verify(p => p.Execute(It.Is<Plan>((plan) => ReferenceEquals(plan, planString))), Times.Once());
+
+            var planInt32 = _target.GetPlan(typeInt32);
+
+            _strategyOneMock.Verify(p => p.Execute(It.Is<Plan>((plan) => ReferenceEquals(plan, planInt32))), Times.Once());
+            _strategyTwoMock.Verify(p => p.Execute(It.Is<Plan>((plan) => ReferenceEquals(plan, planInt32))), Times.Once());
+
+            _strategyOneMock.Verify(p => p.Execute(It.IsAny<Plan>()), Times.Exactly(2));
+            _strategyTwoMock.Verify(p => p.Execute(It.IsAny<Plan>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void CreateEmptyPlan_ShouldThrowArgumentNullExceptionWhenTypeIsNull()
+        {
+            const Type type = null;
+            var planner = new MyPlanner(_strategies);
+
+            var actualException = Assert.Throws<ArgumentNullException>(() => planner.CreateEmptyPlan(type));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(type), actualException.ParamName);
+        }
+
+        public class MyPlanner : Planner
+        {
+            public MyPlanner(IEnumerable<IPlanningStrategy> strategies) : base(strategies)
+            {
+            }
+
+            public new IPlan CreateEmptyPlan(Type type)
+            {
+                return base.CreateEmptyPlan(type);
+            }
+        }
+
+    }
+}

--- a/src/Ninject/Planning/Planner.cs
+++ b/src/Ninject/Planning/Planner.cs
@@ -28,7 +28,6 @@ namespace Ninject.Planning
 
     using Ninject.Components;
     using Ninject.Infrastructure;
-    using Ninject.Infrastructure.Language;
     using Ninject.Planning.Strategies;
 
     /// <summary>
@@ -38,6 +37,7 @@ namespace Ninject.Planning
     {
         private readonly ReaderWriterLockSlim plannerLock = new ReaderWriterLockSlim();
         private readonly Dictionary<Type, IPlan> plans = new Dictionary<Type, IPlan>();
+        private readonly List<IPlanningStrategy> strategies;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Planner"/> class.
@@ -47,13 +47,16 @@ namespace Ninject.Planning
         {
             Ensure.ArgumentNotNull(strategies, "strategies");
 
-            this.Strategies = strategies.ToList();
+            this.strategies = strategies.ToList();
         }
 
         /// <summary>
         /// Gets the strategies that contribute to the planning process.
         /// </summary>
-        public IList<IPlanningStrategy> Strategies { get; private set; }
+        public IList<IPlanningStrategy> Strategies
+        {
+            get { return this.strategies; }
+        }
 
         /// <summary>
         /// Gets or creates an activation plan for the specified type.
@@ -68,7 +71,12 @@ namespace Ninject.Planning
 
             try
             {
-                return this.plans.TryGetValue(type, out IPlan plan) ? plan : this.CreateNewPlan(type);
+                if (this.plans.TryGetValue(type, out IPlan plan))
+                {
+                    return plan;
+                }
+
+                return this.CreateNewPlan(type);
             }
             finally
             {
@@ -83,8 +91,6 @@ namespace Ninject.Planning
         /// <returns>The created plan.</returns>
         protected virtual IPlan CreateEmptyPlan(Type type)
         {
-            Ensure.ArgumentNotNull(type, "type");
-
             return new Plan(type);
         }
 
@@ -100,23 +106,29 @@ namespace Ninject.Planning
         {
             this.plannerLock.EnterWriteLock();
 
+            IPlan newPlan;
+
             try
             {
+                // Ensure another thread hasn't already created plan for the type
+                // righht before we obtained the write lock
                 if (this.plans.TryGetValue(type, out IPlan plan))
                 {
                     return plan;
                 }
 
-                plan = this.CreateEmptyPlan(type);
-                this.plans.Add(type, plan);
-                this.Strategies.Map(s => s.Execute(plan));
-
-                return plan;
+                newPlan = this.CreateEmptyPlan(type);
+                this.plans.Add(type, newPlan);
             }
             finally
             {
                 this.plannerLock.ExitWriteLock();
             }
+
+            // Execute strategies outside of write lock to ensure we're not
+            // blocking threads that want to create plans for other types
+            this.strategies.ForEach(s => s.Execute(newPlan));
+            return newPlan;
         }
     }
 }


### PR DESCRIPTION
Improves performance and parallelism, and reduces allocations in **Planner** by:
* Eliminating virtual method calls.
* Using `List<T>.ForEach(Action<T> action)` instead of `ExtensionsForIEnumerableOfT.Map<T>(this IEnumerable<T> series, Action<T> action)`.
* Executing strategies outside of write lock.
* Removing duplicate null check in `Planner.CreateEmptyPlan(Type type)`.

** Before:**

|                            Method |        Mean |      Error |     StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------------- |------------:|-----------:|-----------:|------------:|------------:|------------:|--------------------:|
|           GetPlan_Existing_Serial |    40.68 ns |  0.0496 ns |  0.0464 ns |           - |           - |           - |                   - |
|         GetPlan_Existing_Parallel |   263.68 ns |  5.2703 ns | 14.7786 ns |           - |           - |           - |                   - |
|      GetPlan_New_WithDelay_Serial |   407.55 ns |  1.2374 ns |  1.0969 ns |      0.0608 |      0.0304 |      0.0136 |               257 B |
|   GetPlan_New_WithoutDelay_Serial |   367.22 ns |  1.7601 ns |  1.5603 ns |      0.0608 |      0.0304 |      0.0136 |               257 B |
|    GetPlan_New_WithDelay_Parallel | 1,289.47 ns | 25.2864 ns | 34.6123 ns |      0.0543 |      0.0260 |      0.0087 |                 4 B |
| GetPlan_New_WithoutDelay_Parallel | 1,233.33 ns | 33.7178 ns | 33.1154 ns |      0.0543 |      0.0260 |      0.0087 |                 4 B |

**After:**

|                            Method |        Mean |      Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------------- |------------:|-----------:|----------:|------------:|------------:|------------:|--------------------:|
|           GetPlan_Existing_Serial |    40.46 ns |  0.8365 ns |  1.117 ns |           - |           - |           - |                   - |
|         GetPlan_Existing_Parallel |   193.65 ns |  3.8201 ns |  7.175 ns |           - |           - |           - |                   - |
|      GetPlan_New_WithDelay_Serial |   347.70 ns |  2.3334 ns |  2.183 ns |      0.0505 |      0.0250 |      0.0119 |               217 B |
|   GetPlan_New_WithoutDelay_Serial |   318.24 ns |  3.6420 ns |  3.229 ns |      0.0505 |      0.0250 |      0.0119 |               217 B |
|    GetPlan_New_WithDelay_Parallel | 1,102.92 ns | 21.9722 ns | 25.303 ns |      0.0477 |      0.0239 |      0.0109 |                 4 B |
| GetPlan_New_WithoutDelay_Parallel | 1,125.92 ns | 22.4928 ns | 49.372 ns |      0.0456 |      0.0217 |      0.0087 |                 4 B |
