### PR TITLE
Improve performance and reduce allocations further for Plan.

### DIFF
--- a/src/Ninject.Benchmarks/Planning/PlanBenchmark.cs
+++ b/src/Ninject.Benchmarks/Planning/PlanBenchmark.cs
@@ -1,0 +1,129 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ninject.Planning;
+using Ninject.Planning.Directives;
+using System;
+
+namespace Ninject.Benchmarks.Planning
+{
+    [MemoryDiagnoser]
+    public class PlanBenchmark
+    {
+        private Plan _plan;
+
+        public PlanBenchmark()
+        {
+            _plan = new Plan(GetType());
+            _plan.Add(new MyDirectiveOne());
+            _plan.Add(CreateConstructorInjectionDirective());
+            _plan.Add(CreateConstructorInjectionDirective());
+            _plan.Add(CreateConstructorInjectionDirective());
+            _plan.Add(CreateConstructorInjectionDirective());
+            _plan.Add(new MyDirectiveTwo());
+            _plan.Add(CreatePropertyInjectionDirective());
+            _plan.Add(CreatePropertyInjectionDirective());
+            _plan.Add(CreatePropertyInjectionDirective());
+            _plan.Add(CreatePropertyInjectionDirective());
+            _plan.Add(CreateMethodInjectionDirective());
+        }
+
+        [Benchmark]
+        public void HasDirective_Match_First()
+        {
+            _plan.Has<MyDirectiveOne>();
+        }
+
+        [Benchmark]
+        public void HasDirective_Match_Middle()
+        {
+            _plan.Has<MyDirectiveTwo>();
+        }
+
+        [Benchmark]
+        public void HasDirective_Match_Last()
+        {
+            _plan.Has<MethodInjectionDirective>();
+        }
+
+        [Benchmark]
+        public void HasDirective_NoMatch()
+        {
+            _plan.Has<MyDirectiveThree>();
+        }
+
+        [Benchmark]
+        public void GetOne_Match_First()
+        {
+            _plan.GetOne<MyDirectiveOne>();
+        }
+
+        [Benchmark]
+        public void GetOne_Match_Middle()
+        {
+            _plan.GetOne<MyDirectiveTwo>();
+        }
+
+        [Benchmark]
+        public void GetOne_Match_Last()
+        {
+            _plan.GetOne<MethodInjectionDirective>();
+        }
+
+        [Benchmark]
+        public void GetOne_NoMatch()
+        {
+            _plan.GetOne<MyDirectiveThree>();
+        }
+
+        [Benchmark]
+        public void GetAll_Match()
+        {
+            _plan.GetAll<ConstructorInjectionDirective>();
+        }
+
+        [Benchmark]
+        public void GetAll_NoMatch()
+        {
+            _plan.GetAll<MyDirectiveThree>();
+        }
+
+        private static ConstructorInjectionDirective CreateConstructorInjectionDirective()
+        {
+            return new ConstructorInjectionDirective(typeof(MyService).GetConstructor(new Type[0]), (_) => null);
+        }
+
+        private static PropertyInjectionDirective CreatePropertyInjectionDirective()
+        {
+            return new PropertyInjectionDirective(typeof(MyService).GetProperty("Name"), (target, value) => { });
+        }
+
+        private static MethodInjectionDirective CreateMethodInjectionDirective()
+        {
+            return new MethodInjectionDirective(typeof(MyService).GetMethod("Run"), (target, arguments) => { });
+        }
+
+        public class MyDirectiveOne : IDirective
+        {
+        }
+
+        public class MyDirectiveTwo : IDirective
+        {
+        }
+
+        public class MyDirectiveThree : IDirective
+        {
+        }
+
+        public class MyService
+        {
+            public MyService()
+            {
+            }
+
+            public string Name { get; }
+
+            public void Run()
+            {
+            }
+        }
+    }
+}

--- a/src/Ninject/Planning/Plan.cs
+++ b/src/Ninject/Planning/Plan.cs
@@ -33,6 +33,8 @@ namespace Ninject.Planning
     /// </summary>
     public class Plan : IPlan
     {
+        private readonly List<IDirective> directives;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Plan"/> class.
         /// </summary>
@@ -42,7 +44,7 @@ namespace Ninject.Planning
             Ensure.ArgumentNotNull(type, "type");
 
             this.Type = type;
-            this.Directives = new List<IDirective>();
+            this.directives = new List<IDirective>();
         }
 
         /// <summary>
@@ -53,7 +55,10 @@ namespace Ninject.Planning
         /// <summary>
         /// Gets the directives defined in the plan.
         /// </summary>
-        public ICollection<IDirective> Directives { get; private set; }
+        public ICollection<IDirective> Directives
+        {
+            get { return this.directives; }
+        }
 
         /// <summary>
         /// Adds the specified directive to the plan.
@@ -63,7 +68,7 @@ namespace Ninject.Planning
         {
             Ensure.ArgumentNotNull(directive, "directive");
 
-            this.Directives.Add(directive);
+            this.directives.Add(directive);
         }
 
         /// <summary>
@@ -96,9 +101,10 @@ namespace Ninject.Planning
         public IEnumerable<TDirective> GetAll<TDirective>()
             where TDirective : IDirective
         {
-            foreach (var directive in this.Directives)
+            var directiveCount = this.directives.Count;
+            for (var i = 0; i < directiveCount; i++)
             {
-                if (directive is TDirective tdir)
+                if (this.directives[i] is TDirective tdir)
                 {
                     yield return tdir;
                 }


### PR DESCRIPTION
Improves performance and reduces allocations further for **Plan**.

**Before:**


|                    Method |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------- |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|  HasDirective_Match_First |  39.620 ns | 0.2334 ns | 0.2069 ns |      0.0209 |           - |           - |                88 B |
| HasDirective_Match_Middle | 121.500 ns | 1.5366 ns | 1.3622 ns |      0.0207 |           - |           - |                88 B |
|   HasDirective_Match_Last | 189.981 ns | 0.7099 ns | 0.6640 ns |      0.0207 |           - |           - |                88 B |
|      HasDirective_NoMatch | 209.746 ns | 2.0663 ns | 1.9329 ns |      0.0207 |           - |           - |                88 B |
|        GetOne_Match_First | 226.161 ns | 1.0210 ns | 0.8526 ns |      0.0207 |           - |           - |                88 B |
|       GetOne_Match_Middle | 226.589 ns | 0.6180 ns | 0.5781 ns |      0.0207 |           - |           - |                88 B |
|         GetOne_Match_Last | 218.492 ns | 2.5944 ns | 2.4268 ns |      0.0207 |           - |           - |                88 B |
|            GetOne_NoMatch | 219.027 ns | 0.7464 ns | 0.6982 ns |      0.0207 |           - |           - |                88 B |
|              GetAll_Match |   5.787 ns | 0.0383 ns | 0.0358 ns |      0.0114 |           - |           - |                48 B |
|            GetAll_NoMatch |   5.788 ns | 0.0583 ns | 0.0545 ns |      0.0114 |           - |           - |                48 B |

**After:**

|                    Method |       Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|-------------------------- |-----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|  HasDirective_Match_First |  21.112 ns | 0.0925 ns | 0.0865 ns |      0.0114 |           - |           - |                48 B |
| HasDirective_Match_Middle |  57.547 ns | 0.2806 ns | 0.2488 ns |      0.0114 |           - |           - |                48 B |
|   HasDirective_Match_Last |  87.185 ns | 0.3018 ns | 0.2823 ns |      0.0113 |           - |           - |                48 B |
|      HasDirective_NoMatch |  88.213 ns | 0.6356 ns | 0.5945 ns |      0.0113 |           - |           - |                48 B |
|        GetOne_Match_First | 105.659 ns | 0.2109 ns | 0.1973 ns |      0.0113 |           - |           - |                48 B |
|       GetOne_Match_Middle | 107.370 ns | 0.8670 ns | 0.7240 ns |      0.0113 |           - |           - |                48 B |
|         GetOne_Match_Last | 104.215 ns | 0.3294 ns | 0.2751 ns |      0.0113 |           - |           - |                48 B |
|            GetOne_NoMatch | 101.319 ns | 0.5658 ns | 0.5016 ns |      0.0113 |           - |           - |                48 B |
|              GetAll_Match |   5.602 ns | 0.0371 ns | 0.0347 ns |      0.0114 |           - |           - |                48 B |
|            GetAll_NoMatch |   5.642 ns | 0.0498 ns | 0.0441 ns |      0.0114 |           - |           - |                48 B |
