### PR TITLE
Minor speedup for creation of constructor and method injector

### DIFF
--- a/src/Ninject.Benchmarks/Injection/ExpressionInjectorFactoryBenchmark.cs
+++ b/src/Ninject.Benchmarks/Injection/ExpressionInjectorFactoryBenchmark.cs
@@ -1,0 +1,59 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExpressionInjectorFactoryBenchmark.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2007-2010 Enkari, Ltd. All rights reserved.
+//   Copyright (c) 2010-2017 Ninject Project Contributors. All rights reserved.
+//
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   You may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace Ninject.Benchmarks.Injection
+{
+    using System.Reflection;
+    using BenchmarkDotNet.Attributes;
+
+    using Ninject.Injection;
+    using Ninject.Tests.Fakes;
+
+    [MemoryDiagnoser]
+    public class ExpressionInjectorFactoryBenchmark
+    {
+        private ExpressionInjectorFactory _injectorFactory;
+        private ConstructorInfo _constructorWarriorAndWeapon;
+        private object[] _argumentsWarriorAndWeapon;
+        private ConstructorInjector _injector;
+
+        public ExpressionInjectorFactoryBenchmark()
+        {
+            _injectorFactory = new ExpressionInjectorFactory();
+
+            _constructorWarriorAndWeapon = typeof(NinjaBarracks).GetConstructor(new[] { typeof(IWarrior), typeof(IWeapon) });
+            _argumentsWarriorAndWeapon = new object[] { new FootSoldier(), new Sword() };
+            _injector = _injectorFactory.Create(_constructorWarriorAndWeapon);
+        }
+
+        [Benchmark]
+        public void Create_ConstructorInfo()
+        {
+            _injectorFactory.Create(_constructorWarriorAndWeapon);
+        }
+
+        [Benchmark]
+        public void InvokeInjector()
+        {
+            _injector(_argumentsWarriorAndWeapon);
+        }
+    }
+}

--- a/src/Ninject.Benchmarks/Injection/ReflectionInjectorFactoryBenchmark.cs
+++ b/src/Ninject.Benchmarks/Injection/ReflectionInjectorFactoryBenchmark.cs
@@ -1,0 +1,59 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReflectionInjectorFactoryBenchmark.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2007-2010 Enkari, Ltd. All rights reserved.
+//   Copyright (c) 2010-2017 Ninject Project Contributors. All rights reserved.
+//
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   You may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace Ninject.Benchmarks.Injection
+{
+    using System.Reflection;
+    using BenchmarkDotNet.Attributes;
+
+    using Ninject.Injection;
+    using Ninject.Tests.Fakes;
+
+    [MemoryDiagnoser]
+    public class ReflectionInjectorFactoryBenchmark
+    {
+        private ReflectionInjectorFactory _injectorFactory;
+        private ConstructorInfo _constructorWarriorAndWeapon;
+        private object[] _argumentsWarriorAndWeapon;
+        private ConstructorInjector _injector;
+
+        public ReflectionInjectorFactoryBenchmark()
+        {
+            _injectorFactory = new ReflectionInjectorFactory();
+
+            _constructorWarriorAndWeapon = typeof(NinjaBarracks).GetConstructor(new[] { typeof(IWarrior), typeof(IWeapon) });
+            _argumentsWarriorAndWeapon = new object[] { new FootSoldier(), new Sword() };
+            _injector = _injectorFactory.Create(_constructorWarriorAndWeapon);
+        }
+
+        [Benchmark]
+        public void Create_ConstructorInfo()
+        {
+            _injectorFactory.Create(_constructorWarriorAndWeapon);
+        }
+
+        [Benchmark]
+        public void InvokeInjector()
+        {
+            _injector(_argumentsWarriorAndWeapon);
+        }
+    }
+}


### PR DESCRIPTION
Minor speedup for creation of constructor and method injector in **ExpressionInjectorFactory**, and reduce allocations.

Add benchmarks for **ExpressionInjectorFactory** and **ReflectionInjectorFactory**.

**Before:**

|                 Method |           Mean |         Error |        StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|----------------------- |---------------:|--------------:|--------------:|------------:|------------:|------------:|--------------------:|
| Create_ConstructorInfo | 128,727.325 ns | 1,968.6996 ns | 1,841.5228 ns |      1.2207 |      0.4883 |           - |              5616 B |

**After:**

|                 Method |           Mean |       Error |      StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|----------------------- |---------------:|------------:|------------:|------------:|------------:|------------:|--------------------:|
| Create_ConstructorInfo | 123,889.301 ns | 179.3502 ns | 149.7656 ns |      1.2207 |      0.4883 |           - |              5456 B |



