### PR TITLE
Introduce ShouldInject overloads in IInjectionHeuristic

### DIFF
--- a/src/Ninject/Selection/Heuristics/IInjectionHeuristic.cs
+++ b/src/Ninject/Selection/Heuristics/IInjectionHeuristic.cs
@@ -31,10 +31,17 @@ namespace Ninject.Selection.Heuristics
     public interface IInjectionHeuristic : INinjectComponent
     {
         /// <summary>
-        /// Returns a value indicating whether the specified member should be injected.
+        /// Returns a value indicating whether the specified property should be injected.
         /// </summary>
-        /// <param name="member">The member in question.</param>
-        /// <returns><c>True</c> if the member should be injected; otherwise <c>false</c>.</returns>
-        bool ShouldInject(MemberInfo member);
+        /// <param name="property">The property in question.</param>
+        /// <returns><c>true</c> if the property should be injected; otherwise <c>false</c>.</returns>
+        bool ShouldInject(PropertyInfo property);
+
+        /// <summary>
+        /// Returns a value indicating whether the specified method should be injected.
+        /// </summary>
+        /// <param name="method">The method in question.</param>
+        /// <returns><c>true</c> if the method should be injected; otherwise <c>false</c>.</returns>
+        bool ShouldInject(MethodInfo method);
     }
 }

--- a/src/Ninject/Selection/Heuristics/StandardInjectionHeuristic.cs
+++ b/src/Ninject/Selection/Heuristics/StandardInjectionHeuristic.cs
@@ -50,22 +50,29 @@ namespace Ninject.Selection.Heuristics
         }
 
         /// <summary>
-        /// Returns a value indicating whether the specified member should be injected.
+        /// Returns a value indicating whether the specified property should be injected.
         /// </summary>
-        /// <param name="member">The member in question.</param>
-        /// <returns><c>True</c> if the member should be injected; otherwise <c>false</c>.</returns>
-        public virtual bool ShouldInject(MemberInfo member)
+        /// <param name="property">The property in question.</param>
+        /// <returns><c>true</c> if the property should be injected; otherwise <c>false</c>.</returns>
+        public virtual bool ShouldInject(PropertyInfo property)
         {
-            Ensure.ArgumentNotNull(member, "member");
+            Ensure.ArgumentNotNull(property, nameof(property));
 
-            if (member is PropertyInfo propertyInfo)
-            {
-                var setMethod = propertyInfo.GetSetMethod(this.settings.InjectNonPublic);
+            var setMethod = property.GetSetMethod(this.settings.InjectNonPublic);
 
-                return member.HasAttribute(this.settings.InjectAttribute) && setMethod != null;
-            }
+            return setMethod != null && property.HasAttribute(this.settings.InjectAttribute);
+        }
 
-            return member.HasAttribute(this.settings.InjectAttribute);
+        /// <summary>
+        /// Returns a value indicating whether the specified method should be injected.
+        /// </summary>
+        /// <param name="method">The method in question.</param>
+        /// <returns><c>true</c> if the method should be injected; otherwise <c>false</c>.</returns>
+        public virtual bool ShouldInject(MethodInfo method)
+        {
+            Ensure.ArgumentNotNull(method, nameof(method));
+
+            return method.HasAttribute(this.settings.InjectAttribute);
         }
     }
 }


### PR DESCRIPTION
Eliminate runtime type checks by introducing the following overloads:
* `bool ShouldInject(PropertyInfo property)` 
* `bool ShouldInject(MethodInfo method)`

I also removed the `bool ShouldInject(MemberInfo member)` overload, as that one is no longer used.
Note that this is a breaking change (but I doubt it affects anyone).