### PR TITLE
Use Assembly.LoadFile instead of Assembly.LoadFrom

### DIFF
--- a/src/Ninject.Test/Unit/AssemblyNameRetrieverTests.cs
+++ b/src/Ninject.Test/Unit/AssemblyNameRetrieverTests.cs
@@ -36,22 +36,6 @@ namespace Ninject.Tests.Unit
         }
     }
 
-    public class WhenGetAssemblyNamesIsCalledWithAssemblyName : AssemblyNameRetrieverContext
-    {
-        [Fact]
-        public void AssemblyNamesOfMatchingAssembliesAreReturned()
-        {
-            var expected = Assembly.LoadFrom(this.ModuleFilename).GetName();
-
-            var actualNames = this.AssemblyNameRetriever.GetAssemblyNames(
-                new[] { expected.FullName },
-                asm => true);
-
-            var assemblyFullNames = actualNames.Select(a => a.FullName).ToList();
-            assemblyFullNames.Should().BeEquivalentTo(new[] { expected.FullName });
-        }
-    }
-
     public class WhenGetAssemblyNamesIsCalledWithUnknownAssemblyName : AssemblyNameRetrieverContext
     {
         [Fact]

--- a/src/Ninject/Modules/AssemblyNameRetriever.cs
+++ b/src/Ninject/Modules/AssemblyNameRetriever.cs
@@ -30,7 +30,7 @@ namespace Ninject.Modules
     using Ninject.Components;
 
     /// <summary>
-    /// Retrieves assembly names from file paths with isolate.
+    /// Retrieves assembly names from file paths with isolation.
     /// </summary>
     public class AssemblyNameRetriever : NinjectComponent, IAssemblyNameRetriever
     {

--- a/src/Ninject/Modules/IAssemblyNameRetriever.cs
+++ b/src/Ninject/Modules/IAssemblyNameRetriever.cs
@@ -28,7 +28,7 @@ namespace Ninject.Modules
     using Ninject.Components;
 
     /// <summary>
-    /// Retrieves assembly names from file paths with isolate.
+    /// Retrieves assembly names from file paths with isolation.
     /// </summary>
     public interface IAssemblyNameRetriever : INinjectComponent
     {

--- a/src/Ninject/Modules/IAssemblyNameRetriever.cs
+++ b/src/Ninject/Modules/IAssemblyNameRetriever.cs
@@ -28,16 +28,16 @@ namespace Ninject.Modules
     using Ninject.Components;
 
     /// <summary>
-    /// Retrieves assembly names from file names using a temporary app domain.
+    /// Retrieves assembly names from file paths with isolate.
     /// </summary>
     public interface IAssemblyNameRetriever : INinjectComponent
     {
         /// <summary>
         /// Gets all assembly names of the assemblies in the given files that match the filter.
         /// </summary>
-        /// <param name="filenames">The filenames.</param>
+        /// <param name="filepaths">The file paths.</param>
         /// <param name="filter">The filter.</param>
         /// <returns>All assembly names of the assemblies in the given files that match the filter.</returns>
-        IEnumerable<AssemblyName> GetAssemblyNames(IEnumerable<string> filenames, Predicate<Assembly> filter);
+        IEnumerable<AssemblyName> GetAssemblyNames(IEnumerable<string> filepaths, Predicate<Assembly> filter);
     }
 }


### PR DESCRIPTION
Fixed https://github.com/ninject/Ninject/issues/295
The file names are actually file full paths: https://github.com/ninject/Ninject/blob/master/src/Ninject/Modules/ModuleLoader.cs#L80
And the **Assembly.LoadFile** will load the assmebly into a new (anonymous) load context. https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/assemblyloadcontext.md#assembly-load-apis-and-loadcontext