### PR TITLE
Move and remove duplicate null checks

### DIFF
--- a/src/Ninject.Test/Unit/Activation/RequestTests.cs
+++ b/src/Ninject.Test/Unit/Activation/RequestTests.cs
@@ -1,0 +1,41 @@
+﻿using Ninject.Activation;
+using Ninject.Parameters;
+using Ninject.Planning.Bindings;
+using System;
+using Xunit;
+
+namespace Ninject.Test.Unit.Activation
+{
+    public class RequestTests
+    {
+        [Fact]
+        public void Constructor_ShouldThrowArgumentNullExceptionWhenServiceIsNull()
+        {
+            const Type service = null;
+            Func<IBindingMetadata, bool> constraint = bindingMetadata => true;
+            var parameters = new IParameter[0];
+            Func<object> scopeCallback = () => { return null; };
+
+            var actual = Assert.Throws<ArgumentNullException>(()
+                => new Request(service, constraint, parameters, scopeCallback, false, false));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(service), actual.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowArgumentNullExceptionWhenParametersIsNull()
+        {
+            var service = typeof(RequestTests);
+            Func<IBindingMetadata, bool> constraint = bindingMetadata => true;
+            IParameter[] parameters = null;
+            Func<object> scopeCallback = () => { return null; };
+
+            var actual = Assert.Throws<ArgumentNullException>(()
+                => new Request(service, constraint, parameters, scopeCallback, false, false));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(parameters), actual.ParamName);
+        }
+    }
+}

--- a/src/Ninject.Test/Unit/ReadOnlyKernelTests.cs
+++ b/src/Ninject.Test/Unit/ReadOnlyKernelTests.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using Ninject.Activation;
+using Ninject.Activation.Caching;
+using Ninject.Parameters;
+using Ninject.Planning;
+using Ninject.Planning.Bindings;
+using Ninject.Planning.Bindings.Resolvers;
+using Ninject.Selection.Heuristics;
+using Ninject.Syntax;
+using Xunit;
+
+namespace Ninject.Test.Unit
+{
+    public class ReadOnlyKernelTests
+    {
+        private Mock<INinjectSettings> _ninjectSettingsMock;
+        private Mock<ICache> _cacheMock;
+        private Mock<IPlanner> _plannerMock;
+        private Mock<IConstructorScorer> _constructorScorerMock;
+        private Mock<IPipeline> _pipelineMock;
+        private Mock<IBindingPrecedenceComparer> _bindingPrecedenceComparerMock;
+        private Mock<IBindingResolver> _bindingResolverMock1;
+        private Mock<IBindingResolver> _bindingResolverMock2;
+        private Mock<IMissingBindingResolver> _missingBindingResolverMock1;
+        private Mock<IMissingBindingResolver> _missingBindingResolverMock2;
+        private IEnumerable<IBindingResolver> _bindingResolvers;
+        private IEnumerable<IMissingBindingResolver> _missingBindingResolvers;
+
+        public ReadOnlyKernelTests()
+        {
+            _ninjectSettingsMock = new Mock<INinjectSettings>(MockBehavior.Strict);
+            _cacheMock = new Mock<ICache>(MockBehavior.Strict);
+            _plannerMock = new Mock<IPlanner>(MockBehavior.Strict);
+            _constructorScorerMock = new Mock<IConstructorScorer>(MockBehavior.Strict);
+            _pipelineMock = new Mock<IPipeline>(MockBehavior.Strict);
+            _bindingPrecedenceComparerMock = new Mock<IBindingPrecedenceComparer>(MockBehavior.Strict);
+            _bindingResolverMock1 = new Mock<IBindingResolver>(MockBehavior.Strict);
+            _bindingResolverMock2 = new Mock<IBindingResolver>(MockBehavior.Strict);
+            _missingBindingResolverMock1 = new Mock<IMissingBindingResolver>(MockBehavior.Strict);
+            _missingBindingResolverMock2 = new Mock<IMissingBindingResolver>(MockBehavior.Strict);
+
+            _bindingResolvers = new List<IBindingResolver>
+                {
+                    _bindingResolverMock1.Object,
+                    _bindingResolverMock2.Object
+                };
+            _missingBindingResolvers = new List<IMissingBindingResolver>
+                {
+                    _missingBindingResolverMock1.Object,
+                    _missingBindingResolverMock2.Object
+                };
+        }
+
+        [Fact]
+        public void CreateContext_ShouldThrowArgumentNullExceptionWhenRequestIsNull()
+        {
+            var bindings = new Dictionary<Type, ICollection<IBinding>>();
+            var readOnlyKernel = CreateReadOnlyKernel(bindings);
+
+            const IRequest request = null;
+            var bindingMock = new Mock<IBinding>(MockBehavior.Strict);
+
+            var actual = Assert.Throws<ArgumentNullException>(() => readOnlyKernel.CreateContext(request, bindingMock.Object));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(request), actual.ParamName);
+        }
+
+        [Fact]
+        public void CreateContext_ShouldThrowArgumentNullExceptionWhenBindingIsNull()
+        {
+            var bindings = new Dictionary<Type, ICollection<IBinding>>();
+            var readOnlyKernel = CreateReadOnlyKernel(bindings);
+
+            var requestMock = new Mock<IRequest>(MockBehavior.Strict);
+            const IBinding binding = null;
+
+            var actual = Assert.Throws<ArgumentNullException>(() => readOnlyKernel.CreateContext(requestMock.Object, binding));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(binding), actual.ParamName);
+        }
+
+        [Fact]
+        public void CreateRequest_ShouldThrowArgumentNullExceptionWhenServiceIsNull()
+        {
+            var bindings = new Dictionary<Type, ICollection<IBinding>>();
+            var readOnlyKernel = CreateReadOnlyKernel(bindings);
+
+            const Type service = null;
+            Func<IBindingMetadata, bool> constraint = bindingMetadata => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(() => readOnlyKernel.CreateRequest(service, constraint, parameters, true, false));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(service), actual.ParamName);
+        }
+
+        [Fact]
+        public void CreateRequest_ShouldThrowArgumentNullExceptionWhenParametersIsNull()
+        {
+            var bindings = new Dictionary<Type, ICollection<IBinding>>();
+            var readOnlyKernel = CreateReadOnlyKernel(bindings);
+
+            var service = typeof(string);
+            Func<IBindingMetadata, bool> constraint = bindingMetadata => true;
+            IParameter[] parameters = null;
+
+            var actual = Assert.Throws<ArgumentNullException>(() => readOnlyKernel.CreateRequest(service, constraint, parameters, true, false));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(parameters), actual.ParamName);
+        }
+
+        [Fact]
+        public void Inject_ShouldThrowArgumentNullExceptionWhenInstanceIsNull()
+        {
+            var bindings = new Dictionary<Type, ICollection<IBinding>>();
+            var readOnlyKernel = CreateReadOnlyKernel(bindings);
+
+            const object instance = null;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(() => readOnlyKernel.Inject(instance, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(instance), actual.ParamName);
+        }
+
+        [Fact]
+        public void Inject_ShouldThrowArgumentNullExceptionWhenParametersIsNull()
+        {
+            var bindings = new Dictionary<Type, ICollection<IBinding>>();
+            var readOnlyKernel = CreateReadOnlyKernel(bindings);
+
+            var instance = new object();
+            IParameter[] parameters = null;
+
+            var actual = Assert.Throws<ArgumentNullException>(() => readOnlyKernel.Inject(instance, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(parameters), actual.ParamName);
+        }
+
+        private MyReadOnlyKernel CreateReadOnlyKernel(IDictionary<Type, ICollection<IBinding>> bindings)
+        {
+            var sequence = new MockSequence();
+            _bindingResolverMock1.InSequence(sequence)
+                                 .Setup(p => p.Resolve(It.IsAny<IDictionary<Type, ICollection<IBinding>>>(), typeof(IReadOnlyKernel)))
+                                 .Returns(Enumerable.Empty<IBinding>);
+            _bindingResolverMock2.InSequence(sequence)
+                                 .Setup(p => p.Resolve(It.IsAny<IDictionary<Type, ICollection<IBinding>>>(), typeof(IReadOnlyKernel)))
+                                 .Returns(Enumerable.Empty<IBinding>);
+            _bindingResolverMock1.InSequence(sequence)
+                                 .Setup(p => p.Resolve(It.IsAny<IDictionary<Type, ICollection<IBinding>>>(), typeof(IResolutionRoot)))
+                                 .Returns(Enumerable.Empty<IBinding>);
+            _bindingResolverMock2.InSequence(sequence)
+                                 .Setup(p => p.Resolve(It.IsAny<IDictionary<Type, ICollection<IBinding>>>(), typeof(IResolutionRoot)))
+                                 .Returns(Enumerable.Empty<IBinding>);
+
+            return new MyReadOnlyKernel(_ninjectSettingsMock.Object,
+                                        bindings,
+                                        _cacheMock.Object,
+                                        _plannerMock.Object,
+                                        _constructorScorerMock.Object,
+                                        _pipelineMock.Object,
+                                        _bindingPrecedenceComparerMock.Object,
+                                        _bindingResolvers,
+                                        _missingBindingResolvers);
+        }
+
+        public class MyReadOnlyKernel : ReadOnlyKernel
+        {
+            internal MyReadOnlyKernel(INinjectSettings settings,
+                                      IDictionary<Type, ICollection<IBinding>> bindings,
+                                      ICache cache,
+                                      IPlanner planner,
+                                      IConstructorScorer constructorScorer,
+                                      IPipeline pipeline,
+                                      IBindingPrecedenceComparer bindingPrecedenceComparer,
+                                      IEnumerable<IBindingResolver> bindingResolvers,
+                                      IEnumerable<IMissingBindingResolver> missingBindingResolvers)
+                : base(settings,
+                       bindings,
+                       cache,
+                       planner,
+                       constructorScorer,
+                       pipeline,
+                       bindingPrecedenceComparer,
+                       bindingResolvers,
+                       missingBindingResolvers)
+            {
+            }
+
+            public new IContext CreateContext(IRequest request, IBinding binding)
+            {
+                return base.CreateContext(request, binding);
+            }
+        }
+    }
+}

--- a/src/Ninject.Test/Unit/ResolutionExtensionsTests.cs
+++ b/src/Ninject.Test/Unit/ResolutionExtensionsTests.cs
@@ -1,0 +1,2103 @@
+﻿using Moq;
+using Ninject.Activation;
+using Ninject.Parameters;
+using Ninject.Planning.Bindings;
+using Ninject.Syntax;
+using Ninject.Tests.Fakes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Ninject.Test.Unit
+{
+    public class ResolutionExtensionsTests
+    {
+        private Mock<IResolutionRoot> _rootMock;
+        private Mock<IRequest> _requestMock;
+        private MockSequence _sequence;
+
+        public ResolutionExtensionsTests()
+        {
+            _rootMock = new Mock<IResolutionRoot>(MockBehavior.Strict);
+            _requestMock = new Mock<IRequest>(MockBehavior.Strict);
+            _sequence = new MockSequence();
+        }
+
+        [Fact]
+        public void CanResolve_RootAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.CanResolve<string>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void CanResolve_RootAndParameters_ParametersIsNull()
+        {
+            var root = _rootMock.Object;
+            IParameter[] parameters = null;
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve<string>(root, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve<string>(root, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndNameAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.CanResolve<string>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void CanResolve_RootAndNameAndParameters_ParametersIsNull()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            IParameter[] parameters = null;
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve<string>(root, name, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve<string>(root, name, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndConstraintAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.CanResolve<string>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+
+        }
+
+        [Fact]
+        public void CanResolve_RootAndConstraintAndParameters_ParametersIsNull()
+        {
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            IParameter[] parameters = null;
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve<string>(_rootMock.Object, constraint, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve<string>(_rootMock.Object, constraint, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var service = typeof(string);
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.CanResolve(root, service, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndParameters_ServiceIsNull()
+        {
+            var root = _rootMock.Object;
+            const Type service = null;
+            var parameters = new IParameter[0];
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, (Func<IBindingMetadata, bool>) null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve(root, service, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, (Func<IBindingMetadata, bool>) null, parameters, false, true)).Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve(root, service, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndParameters_ParametersIsNull()
+        {
+            var root = _rootMock.Object;
+            var service = typeof(string);
+            IParameter[] parameters = null;
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, (Func<IBindingMetadata, bool>) null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve(root, service, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, (Func<IBindingMetadata, bool>) null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve(root, service, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndNameAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var service = typeof(string);
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.CanResolve(root, service, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndNameAndParameters_ServiceIsNull()
+        {
+            var root = _rootMock.Object;
+            const Type service = null;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve(root, service, name, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve(root, service, name, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndNameAndParameters_ParametersIsNull()
+        {
+            var root = _rootMock.Object;
+            var service = typeof(string);
+            var name = "NAME";
+            IParameter[] parameters = null;
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve(root, service, name, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve(root, service, name, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndConstraintAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var service = typeof(string);
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.CanResolve(root, service, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndConstraintAndParameters_ServiceIsNull()
+        {
+            var root = _rootMock.Object;
+            const Type service = null;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve(root, service, constraint, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(service, constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve(root, service, constraint, parameters));
+        }
+
+        [Fact]
+        public void CanResolve_RootAndServiceAndConstraintAndParameters_ParametersIsNull()
+        {
+            var root = _rootMock.Object;
+            var service = typeof(string);
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            IParameter[] parameters = null;
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(true);
+
+            Assert.True(ResolutionExtensions.CanResolve(root, service, constraint, parameters));
+
+            _rootMock.Reset();
+            _requestMock.Reset();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CanResolve(_requestMock.Object))
+                     .Returns(false);
+
+            Assert.False(ResolutionExtensions.CanResolve(root, service, constraint, parameters));
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.Get<string>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>)null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains no elements", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.Get<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>)null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWarrior>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>)null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.Get<string>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains no elements", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.Get<IWeapon>(root, constraint, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWarrior>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndConstraintAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.Get<string>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains no elements", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.Get<IWeapon>(root, name, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<string>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(string).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void Get_RootAndNameAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.TryGet<string>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWarrior>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGet<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.TryGet<string>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWarrior>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndConstraintAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.TryGet<string>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, name, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, name, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWarrior>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGet<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGet_RootAndNameAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = ResolutionExtensions.TryGet<IWeapon>(root, name, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<string>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWarrior>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>)null, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<string>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWarrior>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<string>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Same(resolvedInstances[0], actual);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWarrior>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal("Sequence contains more than one element", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+        }
+
+        [Fact]
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
+                     .Returns(_requestMock.Object);
+            _requestMock.InSequence(_sequence)
+                        .SetupSet(p => p.ForceUnique = true);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.GetAll<string>(root, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(resolvedInstances[0], enumerator.Current);
+                Assert.False(enumerator.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>) null, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWarrior>(root, parameters);
+
+            Assert.NotNull(actual);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                var actualException = Assert.Throws<InvalidCastException>(() => enumerator.MoveNext());
+
+                Assert.Null(actualException.InnerException);
+                Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actualException.Message);
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_MultipleInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Equal(resolvedInstances, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, parameters);
+
+            Assert.NotNull(actual);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(resolvedInstances[0], enumerator.Current);
+
+                var actualException = Assert.Throws<InvalidCastException>(() => enumerator.MoveNext());
+
+                Assert.Null(actualException.InnerException);
+                Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actualException.Message);
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.GetAll<IWeapon>(root, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.GetAll<string>(root, constraint, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, constraint, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, constraint, parameters);
+
+            Assert.NotNull(actual);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(resolvedInstances[0], enumerator.Current);
+                Assert.False(enumerator.MoveNext());
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWarrior>(root, constraint, parameters);
+
+            Assert.NotNull(actual);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                var actualException = Assert.Throws<InvalidCastException>(() => enumerator.MoveNext());
+
+                Assert.Null(actualException.InnerException);
+                Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actualException.Message);
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_MultipleInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, constraint, parameters);
+
+            Assert.Equal(resolvedInstances, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, constraint, parameters);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(resolvedInstances[0], enumerator.Current);
+
+                var actualException = Assert.Throws<InvalidCastException>(() => enumerator.MoveNext());
+
+                Assert.Null(actualException.InnerException);
+                Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actualException.Message);
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndConstraintAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            Func<IBindingMetadata, bool> constraint = (_) => true;
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.GetAll<IWeapon>(root, constraint, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_ShouldThrowArgumentNullExceptionWhenRootIsNull()
+        {
+            const IResolutionRoot root = null;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+
+            var actual = Assert.Throws<ArgumentNullException>(
+                () => ResolutionExtensions.GetAll<string>(root, name, parameters));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(root), actual.ParamName);
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_NoInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = Enumerable.Empty<object>();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns(resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, name, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_SingleInstanceOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, name, parameters);
+
+            Assert.NotNull(actual);
+            Assert.Equal(resolvedInstances, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_SingleInstanceNotOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { 5L };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(string), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<string>(root, name, parameters);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                var actualException = Assert.Throws<InvalidCastException>(() => enumerator.MoveNext());
+
+                Assert.Null(actualException.InnerException);
+                Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(string).FullName}'.", actualException.Message);
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_MultipleInstancesOfService()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, name, parameters);
+
+            Assert.Equal(resolvedInstances, actual);
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var resolvedInstances = new object[] { new Dagger(), new Monk() };
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Returns((IEnumerable<object>) resolvedInstances);
+
+            var actual = ResolutionExtensions.GetAll<IWeapon>(root, name, parameters);
+
+            Assert.NotNull(actual);
+
+            using (var enumerator = actual.GetEnumerator())
+            {
+                Assert.True(enumerator.MoveNext());
+                Assert.Same(resolvedInstances[0], enumerator.Current);
+
+                var actualException = Assert.Throws<InvalidCastException>(() => enumerator.MoveNext());
+
+                Assert.Null(actualException.InnerException);
+                Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actualException.Message);
+            }
+        }
+
+        [Fact]
+        public void GetAll_RootAndNameAndParameters_ResolveThrowsActivationException()
+        {
+            var root = _rootMock.Object;
+            var name = "NAME";
+            var parameters = new IParameter[0];
+            var activationException = new ActivationException();
+
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, false))
+                     .Returns(_requestMock.Object);
+            _rootMock.InSequence(_sequence)
+                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Throws(activationException);
+
+            var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.GetAll<IWeapon>(root, name, parameters));
+
+            Assert.Same(activationException, actual);
+        }
+
+    }
+}

--- a/src/Ninject/Activation/Request.cs
+++ b/src/Ninject/Activation/Request.cs
@@ -24,7 +24,7 @@ namespace Ninject.Activation
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using Ninject.Infrastructure;
     using Ninject.Infrastructure.Introspection;
     using Ninject.Parameters;
     using Ninject.Planning.Bindings;
@@ -46,6 +46,9 @@ namespace Ninject.Activation
         /// <param name="isUnique"><c>True</c> if the request should return a unique result; otherwise, <c>false</c>.</param>
         public Request(Type service, Func<IBindingMetadata, bool> constraint, IEnumerable<IParameter> parameters, Func<object> scopeCallback, bool isOptional, bool isUnique)
         {
+            Ensure.ArgumentNotNull(service, "service");
+            Ensure.ArgumentNotNull(parameters, "parameters");
+
             this.Service = service;
             this.Constraint = constraint;
             this.Parameters = parameters;

--- a/src/Ninject/Activation/Request.cs
+++ b/src/Ninject/Activation/Request.cs
@@ -24,6 +24,7 @@ namespace Ninject.Activation
     using System;
     using System.Collections.Generic;
     using System.Linq;
+
     using Ninject.Infrastructure;
     using Ninject.Infrastructure.Introspection;
     using Ninject.Parameters;

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -104,7 +104,6 @@ namespace Ninject
         public void Inject(object instance, params IParameter[] parameters)
         {
             Ensure.ArgumentNotNull(instance, "instance");
-            Ensure.ArgumentNotNull(parameters, "parameters");
 
             var service = instance.GetType();
 
@@ -170,9 +169,6 @@ namespace Ninject
         /// <returns>The request for the specified service.</returns>
         public IRequest CreateRequest(Type service, Func<IBindingMetadata, bool> constraint, IEnumerable<IParameter> parameters, bool isOptional, bool isUnique)
         {
-            Ensure.ArgumentNotNull(service, "service");
-            Ensure.ArgumentNotNull(parameters, "parameters");
-
             return new Request(service, constraint, parameters, null, isOptional, isUnique);
         }
 
@@ -299,9 +295,6 @@ namespace Ninject
         /// <returns>The created context.</returns>
         protected virtual IContext CreateContext(IRequest request, IBinding binding)
         {
-            Ensure.ArgumentNotNull(request, "request");
-            Ensure.ArgumentNotNull(binding, "binding");
-
             return new Context(this, this.settings, request, binding, this.cache, this.planner, this.pipeline);
         }
 

--- a/src/Ninject/Syntax/ResolutionExtensions.cs
+++ b/src/Ninject/Syntax/ResolutionExtensions.cs
@@ -380,8 +380,6 @@ namespace Ninject
         private static bool CanResolve(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IEnumerable<IParameter> parameters, bool isOptional, bool isUnique)
         {
             Ensure.ArgumentNotNull(root, "root");
-            Ensure.ArgumentNotNull(service, "service");
-            Ensure.ArgumentNotNull(parameters, "parameters");
 
             var request = root.CreateRequest(service, constraint, parameters, isOptional, isUnique);
             return root.CanResolve(request);
@@ -390,8 +388,6 @@ namespace Ninject
         private static IEnumerable<object> GetResolutionIterator(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IEnumerable<IParameter> parameters, bool isOptional, bool isUnique)
         {
             Ensure.ArgumentNotNull(root, "root");
-            Ensure.ArgumentNotNull(service, "service");
-            Ensure.ArgumentNotNull(parameters, "parameters");
 
             var request = root.CreateRequest(service, constraint, parameters, isOptional, isUnique);
             return root.Resolve(request);
@@ -400,8 +396,6 @@ namespace Ninject
         private static IEnumerable<object> GetResolutionIterator(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IEnumerable<IParameter> parameters, bool isOptional, bool isUnique, bool forceUnique)
         {
             Ensure.ArgumentNotNull(root, "root");
-            Ensure.ArgumentNotNull(service, "service");
-            Ensure.ArgumentNotNull(parameters, "parameters");
 
             var request = root.CreateRequest(service, constraint, parameters, isOptional, isUnique);
             request.ForceUnique = forceUnique;


### PR DESCRIPTION
* Moves null checks for service and parameters arguments to Request.
* Removes duplicate null checks.
* Add unit tests.