### PR TITLE
Improve performance of NinjectSettings by using simple properties ins…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Dropped support for .NET Framework 4.5. We now only provide support for the .NET Framework 4.6 and .NET Standard 2.0 target frameworks.
 - Changed return value of IBindingResolver (and implementing classes) from `IEnumerable<IBinding>` to `ICollection<IBinding>`.
+- The `T Get<T>(string key, T defaultValue)` and `void Set(string key, object value)` methods have been removed from **(I)NinjectSettings**.
 
 ### Fixed
 - Call `kernel.Get<T>()` two times do not give the same result [#262](https://github.com/ninject/Ninject/issues/262)

--- a/src/Ninject.Benchmarks/NinjectSettingsBenchmark.cs
+++ b/src/Ninject.Benchmarks/NinjectSettingsBenchmark.cs
@@ -1,0 +1,40 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+
+namespace Ninject.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class NinjectSettingsBenchmark
+    {
+        private NinjectSettings _settings;
+
+        public NinjectSettingsBenchmark()
+        {
+            _settings = new NinjectSettings();
+        }
+
+        [Benchmark]
+        public void InjectAttribute()
+        {
+            var injectAttribute = _settings.InjectAttribute;
+            if (injectAttribute == null)
+                throw new System.Exception();
+        }
+
+        [Benchmark]
+        public void CachePruningInterval()
+        {
+            var interval = _settings.CachePruningInterval;
+            if (interval == TimeSpan.Zero)
+                throw new System.Exception();
+        }
+
+        [Benchmark]
+        public void LoadExtensions()
+        {
+            var loadExtensions = _settings.LoadExtensions;
+            if (!loadExtensions)
+                throw new System.Exception();
+        }
+    }
+}

--- a/src/Ninject.Test/Unit/NinjectSettingsTests.cs
+++ b/src/Ninject.Test/Unit/NinjectSettingsTests.cs
@@ -1,0 +1,118 @@
+﻿using Ninject.Activation;
+using Ninject.Infrastructure;
+using Ninject.Tests.Fakes;
+using System;
+using Xunit;
+
+namespace Ninject.Test.Unit
+{
+    public class NinjectSettingsTests
+    {
+        private NinjectSettings _settings;
+
+        public NinjectSettingsTests()
+        {
+            _settings = new NinjectSettings();
+        }
+
+        [Fact]
+        public void InjectAttribute()
+        {
+            Assert.Equal(typeof(InjectAttribute), _settings.InjectAttribute);
+            _settings.InjectAttribute = typeof(Monk);
+            Assert.Equal(typeof(Monk), _settings.InjectAttribute);
+            _settings.InjectAttribute = null;
+            Assert.Null(_settings.InjectAttribute);
+        }
+
+        [Fact]
+        public void CachePruningInterval()
+        {
+            Assert.Equal(TimeSpan.FromSeconds(30), _settings.CachePruningInterval);
+            _settings.CachePruningInterval = TimeSpan.FromMinutes(1);
+            Assert.Equal(TimeSpan.FromMinutes(1), _settings.CachePruningInterval);
+        }
+
+        [Fact]
+        public void DefaultScopeCallback()
+        {
+            Func<IContext, object> myCallback = (context) => new object();
+
+            Assert.Same(StandardScopeCallbacks.Transient, _settings.DefaultScopeCallback);
+            _settings.DefaultScopeCallback = myCallback;
+            Assert.Same(myCallback, _settings.DefaultScopeCallback);
+            _settings.DefaultScopeCallback = null;
+            Assert.Null(_settings.DefaultScopeCallback);
+        }
+
+        [Fact]
+        public void LoadExtensions()
+        {
+            Assert.True(_settings.LoadExtensions);
+            _settings.LoadExtensions = false;
+            Assert.False(_settings.LoadExtensions);
+            _settings.LoadExtensions = true;
+            Assert.True(_settings.LoadExtensions);
+        }
+
+        [Fact]
+        public void ExtensionSearchPatterns()
+        {
+            Assert.Equal(new[] { "Ninject.Extensions.*.dll", "Ninject.Web*.dll" }, _settings.ExtensionSearchPatterns);
+            _settings.ExtensionSearchPatterns = new[] { "Ninject.*.dll" };
+            Assert.Equal(new[] { "Ninject.*.dll" }, _settings.ExtensionSearchPatterns);
+            _settings.ExtensionSearchPatterns = null;
+            Assert.Null(_settings.ExtensionSearchPatterns);
+        }
+
+        [Fact]
+        public void UseReflectionBasedInjection()
+        {
+            Assert.False(_settings.UseReflectionBasedInjection);
+            _settings.UseReflectionBasedInjection = true;
+            Assert.True(_settings.UseReflectionBasedInjection);
+            _settings.UseReflectionBasedInjection = false;
+            Assert.False(_settings.UseReflectionBasedInjection);
+        }
+
+        [Fact]
+        public void InjectNonPublic()
+        {
+            Assert.False(_settings.InjectNonPublic);
+            _settings.InjectNonPublic = true;
+            Assert.True(_settings.InjectNonPublic);
+            _settings.InjectNonPublic = false;
+            Assert.False(_settings.InjectNonPublic);
+        }
+
+        [Fact]
+        public void InjectParentPrivateProperties()
+        {
+            Assert.False(_settings.InjectParentPrivateProperties);
+            _settings.InjectParentPrivateProperties = true;
+            Assert.True(_settings.InjectParentPrivateProperties);
+            _settings.InjectParentPrivateProperties = false;
+            Assert.False(_settings.InjectParentPrivateProperties);
+        }
+
+        [Fact]
+        public void ActivationCacheDisabled()
+        {
+            Assert.False(_settings.ActivationCacheDisabled);
+            _settings.ActivationCacheDisabled = true;
+            Assert.True(_settings.ActivationCacheDisabled);
+            _settings.ActivationCacheDisabled = false;
+            Assert.False(_settings.ActivationCacheDisabled);
+        }
+
+        [Fact]
+        public void AllowNullInjection()
+        {
+            Assert.False(_settings.AllowNullInjection);
+            _settings.AllowNullInjection = true;
+            Assert.True(_settings.AllowNullInjection);
+            _settings.AllowNullInjection = false;
+            Assert.False(_settings.AllowNullInjection);
+        }
+    }
+}

--- a/src/Ninject/INinjectSettings.cs
+++ b/src/Ninject/INinjectSettings.cs
@@ -99,21 +99,5 @@ namespace Ninject
         /// </summary>
         /// <value><c>true</c> if null is allowed as injected value otherwise false.</value>
         bool AllowNullInjection { get; set; }
-
-        /// <summary>
-        /// Gets the value for the specified key.
-        /// </summary>
-        /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="key">The setting's key.</param>
-        /// <param name="defaultValue">The value to return if no setting is available.</param>
-        /// <returns>The value, or the default value if none was found.</returns>
-        T Get<T>(string key, T defaultValue);
-
-        /// <summary>
-        /// Sets the value for the specified key.
-        /// </summary>
-        /// <param name="key">The setting's key.</param>
-        /// <param name="value">The setting's value.</param>
-        void Set(string key, object value);
-    }
+   }
 }

--- a/src/Ninject/NinjectSettings.cs
+++ b/src/Ninject/NinjectSettings.cs
@@ -22,7 +22,6 @@
 namespace Ninject
 {
     using System;
-    using System.Collections.Generic;
 
     using Ninject.Activation;
     using Ninject.Infrastructure;
@@ -32,86 +31,91 @@ namespace Ninject
     /// </summary>
     public class NinjectSettings : INinjectSettings
     {
-        private readonly IDictionary<string, object> values = new Dictionary<string, object>();
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NinjectSettings"/> class.
+        /// </summary>
+        public NinjectSettings()
+        {
+            this.InjectAttribute = typeof(InjectAttribute);
+            this.CachePruningInterval = TimeSpan.FromSeconds(30);
+            this.DefaultScopeCallback = StandardScopeCallbacks.Transient;
+            this.LoadExtensions = true;
+            this.ExtensionSearchPatterns = new[] { "Ninject.Extensions.*.dll", "Ninject.Web*.dll" };
+        }
 
         /// <summary>
         /// Gets or sets the attribute that indicates that a member should be injected.
         /// </summary>
-        public Type InjectAttribute
-        {
-            get { return this.Get("InjectAttribute", typeof(InjectAttribute)); }
-            set { this.Set("InjectAttribute", value); }
-        }
+        /// <value>
+        /// The type of the attribute that indicates that a member should be injected. The default
+        /// is <see cref="InjectAttribute"/>.
+        /// </value>
+        public Type InjectAttribute { get; set; }
 
         /// <summary>
         /// Gets or sets the interval at which the GC should be polled.
         /// </summary>
-        public TimeSpan CachePruningInterval
-        {
-            get { return this.Get("CachePruningInterval", TimeSpan.FromSeconds(30)); }
-            set { this.Set("CachePruningInterval", value); }
-        }
+        /// <value>
+        /// The interval at which the GC should be polled. The default is <c>30</c> seconds.
+        /// </value>
+        public TimeSpan CachePruningInterval { get; set; }
 
         /// <summary>
         /// Gets or sets the default scope callback.
         /// </summary>
-        public Func<IContext, object> DefaultScopeCallback
-        {
-            get { return this.Get("DefaultScopeCallback", StandardScopeCallbacks.Transient); }
-            set { this.Set("DefaultScopeCallback", value); }
-        }
+        public Func<IContext, object> DefaultScopeCallback { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the kernel should automatically load extensions at startup.
         /// </summary>
-        public bool LoadExtensions
-        {
-            get { return this.Get("LoadExtensions", true); }
-            set { this.Set("LoadExtensions", value); }
-        }
+        /// <value>
+        /// <c>true</c> if the kernel should automatically load extensions at startup; otherwise, <c>false</c>.
+        /// The default is <c>true</c>.
+        /// </value>
+        public bool LoadExtensions { get; set; }
 
         /// <summary>
         /// Gets or sets the paths that should be searched for extensions.
         /// </summary>
-        public string[] ExtensionSearchPatterns
-        {
-            get { return this.Get("ExtensionSearchPatterns", new[] { "Ninject.Extensions.*.dll", "Ninject.Web*.dll" }); }
-            set { this.Set("ExtensionSearchPatterns", value); }
-        }
+        /// <value>
+        /// The paths that should be searched for extensions. The default is &quot;Ninject.Extensions.*.dll&quot; and
+        /// &quot;Ninject.Web*.dll&quot;.
+        /// </value>
+        public string[] ExtensionSearchPatterns { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether Ninject should use reflection-based injection instead of
         /// the (usually faster) Expression build system.
         /// </summary>
-        public bool UseReflectionBasedInjection
-        {
-            get { return this.Get("UseReflectionBasedInjection", false); }
-            set { this.Set("UseReflectionBasedInjection", value); }
-        }
+        /// <value>
+        /// <c>true</c> if Ninject should use reflection-based injection; otherwise, <c>false</c>. The default
+        /// is <c>false</c>.
+        /// </value>
+        public bool UseReflectionBasedInjection { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether Ninject should inject non public members.
         /// </summary>
+        /// <value>
+        /// <c>true</c> if Ninject should inject non-public members; otherwise, <c>false</c>.
+        /// The default is <c>false</c>.
+        /// </value>
         [Obsolete("Injecting non public members is not recommended. Make the member(s) public instead.")]
-        public bool InjectNonPublic
-        {
-            get { return this.Get("InjectNonPublic", false); }
-            set { this.Set("InjectNonPublic", value); }
-        }
+        public bool InjectNonPublic { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether Ninject should inject private properties of base classes.
         /// </summary>
+        /// <value>
+        /// <c>true</c> if Ninject should inject into private properties of base classes; otherwise, <c>false</c>.
+        /// The default is <c>false</c>.
+        /// </value>
         /// <remarks>
         /// Activating this setting has an impact on the performance. It is recommended not
         /// to use this feature and use constructor injection instead.
         /// </remarks>
         [Obsolete("Injecting parent private properties is not recommended. Use constructor injection instead.")]
-        public bool InjectParentPrivateProperties
-        {
-            get { return this.Get("InjectParentPrivateProperties", false); }
-            set { this.Set("InjectParentPrivateProperties", value); }
-        }
+        public bool InjectParentPrivateProperties { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the activation cache is disabled.
@@ -125,47 +129,17 @@ namespace Ninject
         /// </code>
         /// </remarks>
         /// <value>
-        ///     <c>true</c> if activation cache is disabled; otherwise, <c>false</c>.
+        /// <c>true</c> if activation cache is disabled; otherwise, <c>false</c>. The default is <c>false</c>.
         /// </value>
-        public bool ActivationCacheDisabled
-        {
-            get { return this.Get("ActivationCacheDisabled", false); }
-            set { this.Set("ActivationCacheDisabled", value); }
-        }
+        public bool ActivationCacheDisabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether Null is a valid value for injection.
         /// By default this is disabled and whenever a provider returns null an exception is thrown.
         /// </summary>
         /// <value>
-        /// <c>true</c> if null is allowed as injected value otherwise false.
+        /// <c>true</c> if null is allowed as injected value; otherwise, <c>false</c>. The default is <c>false</c>.
         /// </value>
-        public bool AllowNullInjection
-        {
-            get { return this.Get("AllowNullInjection", false); }
-            set { this.Set("AllowNullInjection", value); }
-        }
-
-        /// <summary>
-        /// Gets the value for the specified key.
-        /// </summary>
-        /// <typeparam name="T">The type of value to return.</typeparam>
-        /// <param name="key">The setting's key.</param>
-        /// <param name="defaultValue">The value to return if no setting is available.</param>
-        /// <returns>The value, or the default value if none was found.</returns>
-        public T Get<T>(string key, T defaultValue)
-        {
-            return this.values.TryGetValue(key, out object value) ? (T)value : defaultValue;
-        }
-
-        /// <summary>
-        /// Sets the value for the specified key.
-        /// </summary>
-        /// <param name="key">The setting's key.</param>
-        /// <param name="value">The setting's value.</param>
-        public void Set(string key, object value)
-        {
-            this.values[key] = value;
-        }
+        public bool AllowNullInjection { get; set; }
     }
 }


### PR DESCRIPTION
* Improves performance of **NinjectSettings** by using simple properties instead of a **Dictionary**-store hereby avoiding lookups and boxing.
* Removes `T Get<T>(string key, T defaultValue)` and `void Set(string key, object value)` methods from **(I)NinjectSettings**.
* Add unit tests and benchmark.

Fixes #293.