### PR TITLE
Minor performance and allocation improvement for NinjectModule.

### DIFF
--- a/src/Ninject/Modules/NinjectModule.cs
+++ b/src/Ninject/Modules/NinjectModule.cs
@@ -34,12 +34,14 @@ namespace Ninject.Modules
     /// </summary>
     public abstract class NinjectModule : BindingRoot, INinjectModule
     {
+        private readonly List<IBinding> bindings;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NinjectModule"/> class.
         /// </summary>
         protected NinjectModule()
         {
-            this.Bindings = new List<IBinding>();
+            this.bindings = new List<IBinding>();
         }
 
         /// <summary>
@@ -59,7 +61,10 @@ namespace Ninject.Modules
         /// <summary>
         /// Gets the bindings that were registered by the module.
         /// </summary>
-        public ICollection<IBinding> Bindings { get; private set; }
+        public ICollection<IBinding> Bindings
+        {
+            get { return this.bindings; }
+        }
 
         /// <summary>
         /// Gets the kernel configuration that the module is loaded into.
@@ -90,7 +95,7 @@ namespace Ninject.Modules
         public void OnUnload()
         {
             this.Unload();
-            this.Bindings.Map(this.KernelConfiguration.RemoveBinding);
+            this.bindings.ForEach(binding => this.KernelConfiguration.RemoveBinding(binding));
             this.Components = null;
             this.KernelConfiguration = null;
         }
@@ -140,7 +145,7 @@ namespace Ninject.Modules
             Ensure.ArgumentNotNull(binding, "binding");
 
             this.KernelConfiguration.AddBinding(binding);
-            this.Bindings.Add(binding);
+            this.bindings.Add(binding);
         }
 
         /// <summary>
@@ -152,7 +157,7 @@ namespace Ninject.Modules
             Ensure.ArgumentNotNull(binding, "binding");
 
             this.KernelConfiguration.RemoveBinding(binding);
-            this.Bindings.Remove(binding);
+            this.bindings.Remove(binding);
         }
     }
 }


### PR DESCRIPTION
* Introduce a **List\<IBinding>** backing field for **NinjectModule.Bindings**. This eliminates a few virtual method calls.
* Use `List<T>.ForEach(Action<T> action)` instead of `ExtensionsForIEnumerable.Map<T>(this IEnumerable<T> series, Action<T> action)`, and no longer use method group to reduce allocations.