### PR TITLE
Remove extra lookup and argument check in BindingMetadata

### DIFF
--- a/src/Ninject.Test/Unit/Planning/Bindings/BindingMetadataTests.cs
+++ b/src/Ninject.Test/Unit/Planning/Bindings/BindingMetadataTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Xunit;
+using Ninject.Planning.Bindings;
+
+
+namespace Ninject.Tests.Unit.Planning.Bindings
+{
+    public class BindingMetadataTests
+    {
+        private BindingMetadata _bindingMetadata;
+
+        public BindingMetadataTests()
+        {
+            _bindingMetadata = new BindingMetadata();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetOfT_Key_ShouldThrowArgumentExceptionWhenKeyKeyIsNullOrEmpty(string key)
+        {
+            var actualException = Assert.Throws<ArgumentException>(() => _bindingMetadata.Get<int>(key));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(key), actualException.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void GetOfT_KeyAndDefaultValue_ShouldThrowArgumentExceptionWhenKeyIsNullOrEmpty(string key)
+        {
+            var actualException = Assert.Throws<ArgumentException>(() => _bindingMetadata.Get<int>(key, 5));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(key), actualException.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Has_ShouldThrowArgumentExceptionWhenKeyIsNullOrEmpty(string key)
+        {
+            var actualException = Assert.Throws<ArgumentException>(() => _bindingMetadata.Has(key));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(key), actualException.ParamName);
+        }
+
+        [Fact]
+        public void Has_ShouldReturnFalseWhenKeyDoesNotExist()
+        {
+            Assert.False(_bindingMetadata.Has("name"));
+            _bindingMetadata.Set("Name", "Foo");
+            Assert.False(_bindingMetadata.Has("name"));
+        }
+
+        [Fact]
+        public void Has_ShouldReturnTrueWhenKeyExists()
+        {
+            _bindingMetadata.Set("name", "Foo");
+            Assert.True(_bindingMetadata.Has("name"));
+
+            _bindingMetadata.Set("address", null);
+            Assert.True(_bindingMetadata.Has("address"));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Set_ShouldThrowArgumentExceptionWhenKeyIsNullOrEmpty(string key)
+        {
+            var actualException = Assert.Throws<ArgumentException>(() => _bindingMetadata.Set(key, 5));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal(nameof(key), actualException.ParamName);
+        }
+
+        [Theory]
+        [InlineData("name", "Foo")]
+        [InlineData("name", "Bar")]
+        [InlineData("age", 25)]
+        [InlineData("name", null)]
+        public void Set(string key, object value)
+        {
+            _bindingMetadata.Set(key, value);
+
+            Assert.Equal(value, _bindingMetadata.Get<object>(key));
+        }
+
+        [Fact]
+        public void Set_ShouldOverwriteExistingValue()
+        {
+            _bindingMetadata.Set("name", "Foo");
+            _bindingMetadata.Set("name", "Bar");
+
+            Assert.Equal("Bar", _bindingMetadata.Get<string>("name"));
+        }
+    }
+}

--- a/src/Ninject/Planning/Bindings/BindingMetadata.cs
+++ b/src/Ninject/Planning/Bindings/BindingMetadata.cs
@@ -21,6 +21,7 @@
 
 namespace Ninject.Planning.Bindings
 {
+    using System;
     using System.Collections.Generic;
 
     using Ninject.Infrastructure;
@@ -42,7 +43,10 @@ namespace Ninject.Planning.Bindings
         /// Determines whether a piece of metadata with the specified key has been defined.
         /// </summary>
         /// <param name="key">The metadata key.</param>
-        /// <returns><c>True</c> if such a piece of metadata exists; otherwise, <c>false</c>.</returns>
+        /// <returns>
+        /// <see langword="true"/> if such a piece of metadata exists; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public bool Has(string key)
         {
             Ensure.ArgumentNotNullOrEmpty(key, "key");
@@ -56,10 +60,9 @@ namespace Ninject.Planning.Bindings
         /// <typeparam name="T">The type of value to expect.</typeparam>
         /// <param name="key">The metadata key.</param>
         /// <returns>The metadata value.</returns>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public T Get<T>(string key)
         {
-            Ensure.ArgumentNotNullOrEmpty(key, "key");
-
             return this.Get(key, default(T));
         }
 
@@ -70,11 +73,17 @@ namespace Ninject.Planning.Bindings
         /// <param name="key">The metadata key.</param>
         /// <param name="defaultValue">The value to return if the binding has no metadata set with the specified key.</param>
         /// <returns>The metadata value, or the default value if none was set.</returns>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public T Get<T>(string key, T defaultValue)
         {
             Ensure.ArgumentNotNullOrEmpty(key, "key");
 
-            return this.values.ContainsKey(key) ? (T)this.values[key] : defaultValue;
+            if (this.values.TryGetValue(key, out var value))
+            {
+                return (T)value;
+            }
+
+            return defaultValue;
         }
 
         /// <summary>
@@ -82,6 +91,7 @@ namespace Ninject.Planning.Bindings
         /// </summary>
         /// <param name="key">The metadata key.</param>
         /// <param name="value">The metadata value.</param>
+        /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public void Set(string key, object value)
         {
             Ensure.ArgumentNotNullOrEmpty(key, "key");

--- a/src/Ninject/Planning/Bindings/BindingMetadata.cs
+++ b/src/Ninject/Planning/Bindings/BindingMetadata.cs
@@ -49,7 +49,7 @@ namespace Ninject.Planning.Bindings
         /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public bool Has(string key)
         {
-            Ensure.ArgumentNotNullOrEmpty(key, "key");
+            Ensure.ArgumentNotNullOrEmpty(key, nameof(key));
 
             return this.values.ContainsKey(key);
         }
@@ -76,7 +76,7 @@ namespace Ninject.Planning.Bindings
         /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public T Get<T>(string key, T defaultValue)
         {
-            Ensure.ArgumentNotNullOrEmpty(key, "key");
+            Ensure.ArgumentNotNullOrEmpty(key, nameof(key));
 
             if (this.values.TryGetValue(key, out var value))
             {
@@ -94,7 +94,7 @@ namespace Ninject.Planning.Bindings
         /// <exception cref="ArgumentException"><paramref name="key"/> is <see langword="null"/> or a zero-length string.</exception>
         public void Set(string key, object value)
         {
-            Ensure.ArgumentNotNullOrEmpty(key, "key");
+            Ensure.ArgumentNotNullOrEmpty(key, nameof(key));
 
             this.values[key] = value;
         }


### PR DESCRIPTION
* Removes extra lookup in `BindingMetadata.Get<T>(string key)` and `BindingMetadata.Get<T>(string key, T defaultValue)`
* Removes duplicate argument check in `BindingMetadata.Get<T>(string key)`.
* Document exceptions that are thrown.
* Adds unit tests.