### PR TITLE
Improve performane and reduce allocations for MethodInjectionStrategy

### DIFF
--- a/src/Ninject.Benchmarks/Activation/Strategies/MethodInjectionStrategyBenchmark.cs
+++ b/src/Ninject.Benchmarks/Activation/Strategies/MethodInjectionStrategyBenchmark.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Ninject.Activation;
+using Ninject.Activation.Caching;
+using Ninject.Activation.Strategies;
+using Ninject.Components;
+using Ninject.Injection;
+using Ninject.Parameters;
+using Ninject.Planning;
+using Ninject.Tests.Fakes;
+
+namespace Ninject.Benchmarks.Activation.Strategies
+{
+    [MemoryDiagnoser]
+    public class MethodInjectionStrategyBenchmark
+    {
+        private Context _context;
+        private InstanceReference _reference;
+        private MethodInjectionStrategy _methodInjectionStrategy;
+
+        public MethodInjectionStrategyBenchmark()
+        {
+            var injectorFactory = new ExpressionInjectorFactory();
+
+            var ninjectSettings = new NinjectSettings { LoadExtensions = false };
+            var kernelConfiguration = new KernelConfiguration(ninjectSettings);
+            kernelConfiguration.Bind<MyService>().ToSelf();
+            kernelConfiguration.Bind<IWarrior>().To<Monk>();
+            kernelConfiguration.Bind<IWeapon>().To<Sword>();
+
+            _context = CreateContext(kernelConfiguration,
+                                     kernelConfiguration.BuildReadOnlyKernel(),
+                                     Enumerable.Empty<IParameter>(),
+                                     typeof(MyService),
+                                     ninjectSettings);
+            _reference = new InstanceReference { Instance = _context.Resolve() };
+
+            _methodInjectionStrategy = new MethodInjectionStrategy();
+        }
+
+        [Benchmark]
+        public void Activate()
+        {
+            _methodInjectionStrategy.Activate(_context, _reference);
+        }
+
+        private static Context CreateContext(IKernelConfiguration kernelConfiguration, IReadOnlyKernel readonlyKernel, IEnumerable<IParameter> parameters, Type serviceType, INinjectSettings ninjectSettings)
+        {
+            var request = new Request(serviceType,
+                                      null,
+                                      parameters,
+                                      null,
+                                      false,
+                                      true);
+
+            var binding = kernelConfiguration.GetBindings(serviceType).Single();
+
+            return new Context(readonlyKernel,
+                               ninjectSettings,
+                               request,
+                               binding,
+                               kernelConfiguration.Components.Get<ICache>(),
+                               kernelConfiguration.Components.Get<IPlanner>(),
+                               kernelConfiguration.Components.Get<IPipeline>(),
+                               kernelConfiguration.Components.Get<IExceptionFormatter>());
+        }
+
+        public class MyService
+        {
+            public IWarrior Warrior { get; private set; }
+            public IWeapon Weapon { get; private set; }
+
+            public void ConfigureSoldier(IWarrior warrior, IWeapon weapon)
+            {
+                Warrior = warrior;
+                Weapon = weapon;
+            }
+
+            public void Run()
+            {
+            }
+        }
+    }
+}

--- a/src/Ninject.Benchmarks/Activation/Strategies/MethodInjectionStrategyBenchmark.cs
+++ b/src/Ninject.Benchmarks/Activation/Strategies/MethodInjectionStrategyBenchmark.cs
@@ -5,7 +5,6 @@ using BenchmarkDotNet.Attributes;
 using Ninject.Activation;
 using Ninject.Activation.Caching;
 using Ninject.Activation.Strategies;
-using Ninject.Components;
 using Ninject.Injection;
 using Ninject.Parameters;
 using Ninject.Planning;
@@ -63,8 +62,7 @@ namespace Ninject.Benchmarks.Activation.Strategies
                                binding,
                                kernelConfiguration.Components.Get<ICache>(),
                                kernelConfiguration.Components.Get<IPlanner>(),
-                               kernelConfiguration.Components.Get<IPipeline>(),
-                               kernelConfiguration.Components.Get<IExceptionFormatter>());
+                               kernelConfiguration.Components.Get<IPipeline>());
         }
 
         public class MyService

--- a/src/Ninject/Activation/Strategies/MethodInjectionStrategy.cs
+++ b/src/Ninject/Activation/Strategies/MethodInjectionStrategy.cs
@@ -21,10 +21,9 @@
 
 namespace Ninject.Activation.Strategies
 {
-    using System.Linq;
-
     using Ninject.Infrastructure;
     using Ninject.Planning.Directives;
+    using Ninject.Planning.Targets;
 
     /// <summary>
     /// Injects methods on an instance during activation.
@@ -44,9 +43,20 @@ namespace Ninject.Activation.Strategies
 
             foreach (var directive in context.Plan.GetAll<MethodInjectionDirective>())
             {
-                var arguments = directive.Targets.Select(target => target.ResolveWithin(context));
-                directive.Injector(reference.Instance, arguments.ToArray());
+                directive.Injector(reference.Instance, GetMethodArguments(directive.Targets, context));
             }
+        }
+
+        private static object[] GetMethodArguments(ITarget[] targets, IContext context)
+        {
+            var arguments = new object[targets.Length];
+
+            for (var i = 0; i < targets.Length; i++)
+            {
+                arguments[i] = targets[i].ResolveWithin(context);
+            }
+
+            return arguments;
         }
     }
 }


### PR DESCRIPTION
Improves performane and reduce allocations for **MethodInjectionStrategy**.


**Before:**

|   Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
--------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
 Activate | 44.73 ns | 0.8975 ns | 0.7956 ns |      0.0190 |           - |           - |                80 B |

**After:**

|   Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
--------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
 Activate | 28.88 ns | 0.5758 ns | 0.5386 ns |      0.0114 |           - |           - |                48 B |