### PR TITLE
Improve performance and reduce allocations for PropertyInjectionStrategy

### DIFF
--- a/src/Ninject.Benchmarks/Activation/Strategies/MethodInjectionStrategyBenchmark.cs
+++ b/src/Ninject.Benchmarks/Activation/Strategies/MethodInjectionStrategyBenchmark.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Attributes;
 using Ninject.Activation;
 using Ninject.Activation.Caching;
 using Ninject.Activation.Strategies;
+using Ninject.Components;
 using Ninject.Injection;
 using Ninject.Parameters;
 using Ninject.Planning;
@@ -62,7 +63,8 @@ namespace Ninject.Benchmarks.Activation.Strategies
                                binding,
                                kernelConfiguration.Components.Get<ICache>(),
                                kernelConfiguration.Components.Get<IPlanner>(),
-                               kernelConfiguration.Components.Get<IPipeline>());
+                               kernelConfiguration.Components.Get<IPipeline>(),
+                               kernelConfiguration.Components.Get<IExceptionFormatter>());
         }
 
         public class MyService

--- a/src/Ninject.Benchmarks/Activation/Strategies/PropertyInjectionStrategyBenchmark.cs
+++ b/src/Ninject.Benchmarks/Activation/Strategies/PropertyInjectionStrategyBenchmark.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Ninject.Activation;
+using Ninject.Activation.Caching;
+using Ninject.Activation.Strategies;
+using Ninject.Components;
+using Ninject.Injection;
+using Ninject.Parameters;
+using Ninject.Planning;
+using Ninject.Tests.Fakes;
+
+namespace Ninject.Benchmarks.Activation.Strategies
+{
+    [MemoryDiagnoser]
+    public class PropertyInjectionStrategyBenchmark
+    {
+        private InstanceReference _bareReferenceWithPropertyValuesFullMatch;
+        private InstanceReference _bareReferenceWithPropertyValuesPartialMatch;
+        private InstanceReference _bareReferenceWithoutPropertyValues;
+        private InstanceReference _instrumentedReferenceWithPropertyValuesFullMatch;
+        private InstanceReference _instrumentedReferenceWithPropertyValuesPartialMatch;
+        private InstanceReference _instrumentedReferenceWithoutPropertyValues;
+        private PropertyInjectionStrategy _propertyInjectionStrategy;
+        private Context _instrumentedContextWithPropertyValuesFullMatch;
+        private Context _instrumentedContextWithPropertyValuesPartialMatch;
+        private Context _instrumentedContextWithoutPropertyValues;
+        private Context _bareContextWithPropertyValuesFullMatch;
+        private Context _bareContextWithPropertyValuesPartialMatch;
+        private Context _bareContextWithoutPropertyValues;
+
+        public PropertyInjectionStrategyBenchmark()
+        {
+            var ninjectSettings = new NinjectSettings
+                {
+                    // Disable to reduce memory pressure
+                    ActivationCacheDisabled = true,
+                    LoadExtensions = false
+                };
+            var kernelConfiguration = new KernelConfiguration(ninjectSettings);
+            kernelConfiguration.Bind<MyInstrumentedService>().ToSelf();
+            kernelConfiguration.Bind<MyBareService>().ToSelf();
+            kernelConfiguration.Bind<IWarrior>().To<Monk>();
+            kernelConfiguration.Bind<IWeapon>().To<Sword>();
+            kernelConfiguration.Bind<ICleric>().To<Monk>();
+
+            var propertyValuesFullMatch = new List<IPropertyValue>
+                {
+                    new PropertyValue(nameof(MyInstrumentedService.Warrior), new FootSoldier()),
+                    new PropertyValue(nameof(MyInstrumentedService.Weapon), new Dagger()),
+                    new PropertyValue(nameof(MyInstrumentedService.Cleric), new Monk())
+                };
+            var propertyValuesPartialMatch = new List<IPropertyValue>
+                {
+                    new PropertyValue(nameof(MyInstrumentedService.Weapon), new Dagger()),
+                    new PropertyValue(nameof(MyInstrumentedService.Cleric), new Monk())
+                };
+
+            _instrumentedContextWithPropertyValuesFullMatch = CreateContext(kernelConfiguration,
+                                                                            kernelConfiguration.BuildReadOnlyKernel(),
+                                                                            propertyValuesFullMatch,
+                                                                            typeof(MyInstrumentedService),
+                                                                            ninjectSettings);
+            _instrumentedContextWithPropertyValuesPartialMatch = CreateContext(kernelConfiguration,
+                                                                               kernelConfiguration.BuildReadOnlyKernel(),
+                                                                               propertyValuesPartialMatch,
+                                                                               typeof(MyInstrumentedService),
+                                                                               ninjectSettings);
+            _instrumentedContextWithoutPropertyValues = CreateContext(kernelConfiguration,
+                                                                      kernelConfiguration.BuildReadOnlyKernel(),
+                                                                      Enumerable.Empty<IParameter>(),
+                                                                      typeof(MyInstrumentedService),
+                                                                      ninjectSettings);
+            _bareContextWithPropertyValuesFullMatch = CreateContext(kernelConfiguration,
+                                                                    kernelConfiguration.BuildReadOnlyKernel(),
+                                                                    propertyValuesFullMatch,
+                                                                    typeof(MyBareService),
+                                                                    ninjectSettings);
+            _bareContextWithPropertyValuesPartialMatch = CreateContext(kernelConfiguration,
+                                                                       kernelConfiguration.BuildReadOnlyKernel(),
+                                                                       propertyValuesPartialMatch,
+                                                                       typeof(MyBareService),
+                                                                       ninjectSettings);
+            _bareContextWithoutPropertyValues = CreateContext(kernelConfiguration,
+                                                              kernelConfiguration.BuildReadOnlyKernel(),
+                                                              Enumerable.Empty<IParameter>(),
+                                                              typeof(MyBareService),
+                                                              ninjectSettings);
+
+            _bareReferenceWithPropertyValuesFullMatch = new InstanceReference { Instance = _bareContextWithPropertyValuesFullMatch.Resolve() };
+            _bareReferenceWithPropertyValuesPartialMatch = new InstanceReference { Instance = _bareContextWithPropertyValuesPartialMatch.Resolve() };
+            _bareReferenceWithoutPropertyValues = new InstanceReference { Instance = _bareContextWithoutPropertyValues.Resolve() };
+            _instrumentedReferenceWithPropertyValuesFullMatch = new InstanceReference { Instance = _instrumentedContextWithPropertyValuesFullMatch.Resolve() };
+            _instrumentedReferenceWithPropertyValuesPartialMatch = new InstanceReference { Instance = _instrumentedContextWithPropertyValuesPartialMatch.Resolve() };
+            _instrumentedReferenceWithoutPropertyValues = new InstanceReference { Instance = _instrumentedContextWithoutPropertyValues.Resolve() };
+
+            _propertyInjectionStrategy = new PropertyInjectionStrategy(new ExpressionInjectorFactory(), ninjectSettings, new ExceptionFormatter());
+        }
+
+        [Benchmark]
+        public void Activate_WithoutPropertyInjectionDirectivesAndWithPropertyValuesFullMatch()
+        {
+            _propertyInjectionStrategy.Activate(_bareContextWithPropertyValuesFullMatch, _bareReferenceWithPropertyValuesFullMatch);
+        }
+
+        [Benchmark]
+        public void Activate_WithoutPropertyInjectionDirectivesAndWithPropertyValuesPartialMatch()
+        {
+            _propertyInjectionStrategy.Activate(_bareContextWithPropertyValuesPartialMatch, _bareReferenceWithPropertyValuesPartialMatch);
+        }
+
+        [Benchmark]
+        public void Activate_WithoutPropertyInjectionDirectivesAndWithoutPropertyValues()
+        {
+            _propertyInjectionStrategy.Activate(_bareContextWithoutPropertyValues, _bareReferenceWithoutPropertyValues);
+        }
+
+        [Benchmark]
+        public void Activate_WithPropertyInjectionDirectivesAndWithPropertyValuesFullMatch()
+        {
+            _propertyInjectionStrategy.Activate(_instrumentedContextWithPropertyValuesFullMatch, _instrumentedReferenceWithPropertyValuesFullMatch);
+        }
+
+        [Benchmark]
+        public void Activate_WithPropertyInjectionDirectivesAndWithPropertyValuesPartialMatch()
+        {
+            _propertyInjectionStrategy.Activate(_instrumentedContextWithPropertyValuesPartialMatch, _instrumentedReferenceWithPropertyValuesPartialMatch);
+        }
+
+        [Benchmark]
+        public void Activate_WithPropertyInjectionDirectivesAndWithoutPropertyValues()
+        {
+            _propertyInjectionStrategy.Activate(_instrumentedContextWithoutPropertyValues, _instrumentedReferenceWithoutPropertyValues);
+        }
+
+        private static Context CreateContext(IKernelConfiguration kernelConfiguration, IReadOnlyKernel readonlyKernel, IEnumerable<IParameter> parameters, Type serviceType, INinjectSettings ninjectSettings)
+        {
+            var request = new Request(serviceType,
+                                      null,
+                                      parameters,
+                                      null,
+                                      false,
+                                      true);
+
+            var binding = kernelConfiguration.GetBindings(serviceType).Single();
+
+            return new Context(readonlyKernel,
+                               ninjectSettings,
+                               request,
+                               binding,
+                               kernelConfiguration.Components.Get<ICache>(),
+                               kernelConfiguration.Components.Get<IPlanner>(),
+                               kernelConfiguration.Components.Get<IPipeline>(),
+                               kernelConfiguration.Components.Get<IExceptionFormatter>());
+        }
+
+        public class MyInstrumentedService
+        {
+            [Inject]
+            public IWarrior Warrior { get; set; }
+
+            [Inject]
+            public IWeapon Weapon { get; set; }
+
+            [Inject]
+            public ICleric Cleric { get; set; }
+        }
+
+        public class MyBareService
+        {
+            public IWarrior Warrior { get; set; }
+
+            public IWeapon Weapon { get; set; }
+
+            public ICleric Cleric { get; set; }
+        }
+    }
+}

--- a/src/Ninject.Test/Unit/PropertyInjectionStrategyTests.cs
+++ b/src/Ninject.Test/Unit/PropertyInjectionStrategyTests.cs
@@ -2,7 +2,6 @@
 using Moq;
 using Ninject.Activation;
 using Ninject.Activation.Strategies;
-using Ninject.Infrastructure.Language;
 using Ninject.Injection;
 using Ninject.Parameters;
 using Ninject.Planning;
@@ -12,51 +11,103 @@ using Xunit;
 
 namespace Ninject.Tests.Unit.PropertyInjectionStrategyTests
 {
-    using FluentAssertions;
+    using Ninject.Components;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public class PropertyInjectionDirectiveContext
     {
+        protected Mock<IInjectorFactory> injectorFactoryMock { get; private set; }
+        protected Mock<IExceptionFormatter> exceptionFormatterMock { get; private set; }
+        protected Mock<IContext> contextMock { get; private set; }
+        protected Mock<IPlan> planMock { get; private set; }
+        protected Mock<ITargetFactory> targetFactoryMock { get; private set; }
+        protected Random random { get; private set; }
         protected readonly PropertyInjectionStrategy strategy;
 
         public PropertyInjectionDirectiveContext()
         {
-            this.strategy = new PropertyInjectionStrategy(null, new NinjectSettings());
+            this.injectorFactoryMock = new Mock<IInjectorFactory>(MockBehavior.Strict);
+            this.exceptionFormatterMock = new Mock<IExceptionFormatter>(MockBehavior.Strict);
+            this.contextMock = new Mock<IContext>(MockBehavior.Strict);
+            this.planMock = new Mock<IPlan>(MockBehavior.Strict);
+            this.targetFactoryMock = new Mock<ITargetFactory>(MockBehavior.Strict);
+
+            this.random = new Random();
+
+            this.strategy = new PropertyInjectionStrategy(injectorFactoryMock.Object,
+                                                          new NinjectSettings(),
+                                                          this.exceptionFormatterMock.Object);
         }
     }
 
-    public class WhenActivateIsCalled : PropertyInjectionDirectiveContext
+    public class WhenActivateIsCalled_WithProjectInjectionDirectivesAndWithoutPropertyValues : PropertyInjectionDirectiveContext
     {
+        protected Mock<PropertyInjector> fooInjectorMock;
+        protected Mock<PropertyInjector> barInjectorMock;
         protected Dummy instance = new Dummy();
-        protected PropertyInfo property1 = typeof(Dummy).GetProperty("Foo");
-        protected PropertyInfo property2 = typeof(Dummy).GetProperty("Bar");
+        protected PropertyInfo fooProperty = typeof(Dummy).GetProperty("Foo");
+        protected PropertyInfo barProperty = typeof(Dummy).GetProperty("Bar");
+        protected int fooResolvedValue;
+        protected string barResolvedValue;
+        protected Mock<ITarget> fooTargetMock;
+        protected Mock<ITarget> barTargetMock;
         protected InstanceReference reference;
-        protected Mock<IContext> contextMock;
-        protected Mock<IPlan> planMock;
         protected FakePropertyInjectionDirective[] directives;
-        protected PropertyInjector injector1;
-        protected PropertyInjector injector2;
-        protected bool injector1WasCalled;
-        protected bool injector2WasCalled;
 
-        public WhenActivateIsCalled()
+        public WhenActivateIsCalled_WithProjectInjectionDirectivesAndWithoutPropertyValues()
         {
-            this.contextMock = new Mock<IContext>();
-            this.planMock = new Mock<IPlan>();
-            this.injector1 = (x, y) => { this.injector1WasCalled = true; };
-            this.injector2 = (x, y) => { this.injector2WasCalled = true; };
+            this.fooInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.barInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.fooTargetMock = new Mock<ITarget>(MockBehavior.Strict);
+            this.barTargetMock = new Mock<ITarget>(MockBehavior.Strict);
+
+            FakePropertyInjectionDirective.TargetFactory = this.targetFactoryMock.Object;
+
+            var mockSequence = new MockSequence();
+
+            this.targetFactoryMock.InSequence(mockSequence)
+                                  .Setup(p => p.Create(this.fooProperty))
+                                  .Returns(fooTargetMock.Object);
+            this.targetFactoryMock.InSequence(mockSequence)
+                                  .Setup(p => p.Create(this.barProperty))
+                                  .Returns(barTargetMock.Object);
 
             this.directives = new[]
-            {
-                new FakePropertyInjectionDirective(this.property1, this.injector1),
-                new FakePropertyInjectionDirective(this.property2, this.injector2)
-            };
-
-            this.contextMock.SetupGet(x => x.Plan).Returns(this.planMock.Object);
-            this.contextMock.SetupGet(x => x.Parameters).Returns(new IParameter[0]);
-
+                {
+                    new FakePropertyInjectionDirective(this.fooProperty, this.fooInjectorMock.Object),
+                    new FakePropertyInjectionDirective(this.barProperty, this.barInjectorMock.Object)
+                };
             this.reference = new InstanceReference { Instance = this.instance };
+            this.fooResolvedValue = this.random.Next();
+            this.barResolvedValue = this.random.Next().ToString();
 
-            this.planMock.Setup(x => x.GetAll<PropertyInjectionDirective>()).Returns(this.directives);
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Parameters)
+                            .Returns(Array.Empty<IParameter>());
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Plan)
+                            .Returns(this.planMock.Object);
+            this.planMock.InSequence(mockSequence)
+                         .Setup(x => x.GetAll<PropertyInjectionDirective>())
+                         .Returns(this.directives);
+            this.fooTargetMock.InSequence(mockSequence)
+                              .SetupGet(p => p.Name)
+                              .Returns(fooProperty.Name);
+            this.fooTargetMock.InSequence(mockSequence)
+                              .Setup(p => p.ResolveWithin(this.contextMock.Object))
+                              .Returns(fooResolvedValue);
+            this.fooInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.fooResolvedValue));
+            this.barTargetMock.InSequence(mockSequence)
+                              .SetupGet(p => p.Name)
+                              .Returns(barProperty.Name);
+            this.barTargetMock.InSequence(mockSequence)
+                              .Setup(p => p.ResolveWithin(this.contextMock.Object))
+                              .Returns(barResolvedValue);
+            this.barInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.barResolvedValue));
         }
 
         [Fact]
@@ -72,29 +123,405 @@ namespace Ninject.Tests.Unit.PropertyInjectionStrategyTests
         {
             this.strategy.Activate(this.contextMock.Object, this.reference);
 
-            this.directives.Map(d => d.TargetMock.Verify(x => x.ResolveWithin(this.contextMock.Object)));
+            this.fooTargetMock.Verify(p => p.ResolveWithin(this.contextMock.Object), Times.Once());
+            this.barTargetMock.Verify(p => p.ResolveWithin(this.contextMock.Object), Times.Once());
         }
 
         [Fact]
         public void InvokesInjectorsForEachDirective()
         {
             this.strategy.Activate(this.contextMock.Object, this.reference);
-            this.injector1WasCalled.Should().BeTrue();
-            this.injector2WasCalled.Should().BeTrue();
+
+            this.fooInjectorMock.Verify(x => x(this.instance, this.fooResolvedValue), Times.Once());
+            this.barInjectorMock.Verify(x => x(this.instance, this.barResolvedValue), Times.Once());
         }
+    }
+
+    public class WhenActivateIsCalled_WithProjectInjectionDirectivesAndWithPropertyValuesFullMatch : PropertyInjectionDirectiveContext
+    {
+        protected Mock<PropertyInjector> fooInjectorMock;
+        protected Mock<PropertyInjector> barInjectorMock;
+        protected Dummy instance = new Dummy();
+        protected PropertyInfo fooProperty = typeof(Dummy).GetProperty("Foo");
+        protected PropertyInfo barProperty = typeof(Dummy).GetProperty("Bar");
+        protected int fooPropertyValue;
+        protected string barPropertyValue;
+        protected Mock<ITarget> fooTargetMock;
+        protected Mock<ITarget> barTargetMock;
+        protected InstanceReference reference;
+        protected FakePropertyInjectionDirective[] directives;
+        protected IEnumerable<IParameter> parameters;
+
+        public WhenActivateIsCalled_WithProjectInjectionDirectivesAndWithPropertyValuesFullMatch()
+        {
+            this.fooInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.barInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.fooTargetMock = new Mock<ITarget>(MockBehavior.Strict);
+            this.barTargetMock = new Mock<ITarget>(MockBehavior.Strict);
+
+            FakePropertyInjectionDirective.TargetFactory = this.targetFactoryMock.Object;
+
+            var mockSequence = new MockSequence();
+
+            this.targetFactoryMock.InSequence(mockSequence)
+                                  .Setup(p => p.Create(this.fooProperty))
+                                  .Returns(fooTargetMock.Object);
+            this.targetFactoryMock.InSequence(mockSequence)
+                                  .Setup(p => p.Create(this.barProperty))
+                                  .Returns(barTargetMock.Object);
+
+            this.fooPropertyValue = this.random.Next();
+            this.barPropertyValue = this.random.Next().ToString();
+            this.directives = new[]
+                {
+                    new FakePropertyInjectionDirective(this.fooProperty, this.fooInjectorMock.Object),
+                    new FakePropertyInjectionDirective(this.barProperty, this.barInjectorMock.Object)
+                };
+            this.parameters = new List<IParameter>
+                {
+                    new ConstructorArgument("A", "B"),
+                    new PropertyValue(this.fooProperty.Name, fooPropertyValue),
+                    new PropertyValue(this.barProperty.Name, barPropertyValue)
+                };
+            this.reference = new InstanceReference { Instance = this.instance };
+
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Parameters)
+                            .Returns(this.parameters);
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Plan)
+                            .Returns(this.planMock.Object);
+            this.planMock.InSequence(mockSequence)
+                         .Setup(x => x.GetAll<PropertyInjectionDirective>())
+                         .Returns(this.directives);
+            this.fooTargetMock.InSequence(mockSequence)
+                              .SetupGet(p => p.Name)
+                              .Returns(fooProperty.Name);
+            this.fooInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.fooPropertyValue));
+            this.barTargetMock.InSequence(mockSequence)
+                              .SetupGet(p => p.Name)
+                              .Returns(barProperty.Name);
+            this.barInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.barPropertyValue));
+        }
+
+        [Fact]
+        public void ReadsMethodInjectorsFromPlan()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.planMock.Verify(x => x.GetAll<PropertyInjectionDirective>());
+        }
+
+        [Fact]
+        public void InvokesInjectorsForEachDirective()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.fooInjectorMock.Verify(x => x(this.instance, this.fooPropertyValue), Times.Once());
+            this.barInjectorMock.Verify(x => x(this.instance, this.barPropertyValue), Times.Once());
+        }
+    }
+
+    public class WhenActivateIsCalled_WithProjectInjectionDirectivesAndWithPropertyValuesPartialMatch : PropertyInjectionDirectiveContext
+    {
+        protected Mock<PropertyInjector> fooInjectorMock;
+        protected Mock<PropertyInjector> barInjectorMock;
+        protected Mock<PropertyInjector> gooInjectorMock;
+        protected Dummy instance = new Dummy();
+        protected PropertyInfo fooProperty = typeof(Dummy).GetProperty("Foo");
+        protected PropertyInfo barProperty = typeof(Dummy).GetProperty("Bar");
+        protected PropertyInfo gooProperty = typeof(Dummy).GetProperty("Goo");
+        protected int fooPropertyValue;
+        protected string gooPropertyValue;
+        protected string barResolvedValue;
+        protected Mock<ITarget> fooTargetMock;
+        protected Mock<ITarget> barTargetMock;
+        protected Mock<ITarget> gooTargetMock;
+        protected InstanceReference reference;
+        protected FakePropertyInjectionDirective[] directives;
+        protected IEnumerable<IParameter> parameters;
+
+        public WhenActivateIsCalled_WithProjectInjectionDirectivesAndWithPropertyValuesPartialMatch()
+        {
+            this.fooInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.barInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.gooInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.fooTargetMock = new Mock<ITarget>(MockBehavior.Strict);
+            this.barTargetMock = new Mock<ITarget>(MockBehavior.Strict);
+
+            FakePropertyInjectionDirective.TargetFactory = this.targetFactoryMock.Object;
+
+            var mockSequence = new MockSequence();
+
+            this.targetFactoryMock.InSequence(mockSequence)
+                                  .Setup(p => p.Create(this.fooProperty))
+                                  .Returns(fooTargetMock.Object);
+            this.targetFactoryMock.InSequence(mockSequence)
+                                  .Setup(p => p.Create(this.barProperty))
+                                  .Returns(barTargetMock.Object);
+
+            this.fooPropertyValue = this.random.Next();
+            this.gooPropertyValue = this.random.Next().ToString();
+            this.barResolvedValue = this.random.Next().ToString();
+            this.directives = new[]
+                {
+                    new FakePropertyInjectionDirective(this.fooProperty, this.fooInjectorMock.Object),
+                    new FakePropertyInjectionDirective(this.barProperty, this.barInjectorMock.Object)
+                };
+            this.parameters = new List<IParameter>
+                {
+                    new ConstructorArgument("A", "B"),
+                    new PropertyValue(this.fooProperty.Name, fooPropertyValue),
+                    new PropertyValue(this.gooProperty.Name, gooPropertyValue)
+                };
+            this.reference = new InstanceReference { Instance = this.instance };
+
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Parameters)
+                            .Returns(this.parameters);
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Plan)
+                            .Returns(this.planMock.Object);
+            this.planMock.InSequence(mockSequence)
+                         .Setup(x => x.GetAll<PropertyInjectionDirective>())
+                         .Returns(this.directives);
+            this.fooTargetMock.InSequence(mockSequence)
+                              .SetupGet(p => p.Name)
+                              .Returns(fooProperty.Name);
+            this.fooInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.fooPropertyValue));
+            this.barTargetMock.InSequence(mockSequence)
+                              .SetupGet(p => p.Name)
+                              .Returns(barProperty.Name);
+            this.barTargetMock.InSequence(mockSequence)
+                              .Setup(p => p.ResolveWithin(this.contextMock.Object))
+                              .Returns(barResolvedValue);
+            this.barInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.barResolvedValue));
+            this.injectorFactoryMock.InSequence(mockSequence)
+                                    .Setup(p => p.Create(gooProperty))
+                                    .Returns(gooInjectorMock.Object);
+            this.gooInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, this.gooPropertyValue));
+        }
+
+        [Fact]
+        public void ReadsMethodInjectorsFromPlan()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.planMock.Verify(x => x.GetAll<PropertyInjectionDirective>());
+        }
+
+        [Fact]
+        public void ResolvesValuesForDirectivesWithoutPropertyValueParameter()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.barTargetMock.Verify(p => p.ResolveWithin(this.contextMock.Object), Times.Once());
+        }
+
+        [Fact]
+        public void InvokesInjectorsForEachDirectiveWithoutPropertyValue()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.barInjectorMock.Verify(x => x(this.instance, this.barResolvedValue), Times.Once());
+        }
+
+        [Fact]
+        public void InvokesInjectorsForEachPropertyValue()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.fooInjectorMock.Verify(x => x(this.instance, this.fooPropertyValue), Times.Once());
+            this.gooInjectorMock.Verify(x => x(this.instance, this.gooPropertyValue), Times.Once());
+        }
+    }
+
+    public class WhenActivateIsCalled_WithoutProjectInjectionDirectivesAndWithoutPropertyValues : PropertyInjectionDirectiveContext
+    {
+        private Dummy instance;
+        private InstanceReference reference;
+
+        public WhenActivateIsCalled_WithoutProjectInjectionDirectivesAndWithoutPropertyValues()
+        {
+            IEnumerable<IParameter> parameters = new List<IParameter>
+                {
+                    new ConstructorArgument("A", "B")
+                };
+            this.instance = new Dummy();
+            this.reference = new InstanceReference { Instance = this.instance };
+
+            var mockSequence = new MockSequence();
+
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(p => p.Parameters)
+                            .Returns(parameters);
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Plan)
+                            .Returns(this.planMock.Object);
+            this.planMock.InSequence(mockSequence)
+                         .Setup(x => x.GetAll<PropertyInjectionDirective>())
+                         .Returns(Enumerable.Empty<PropertyInjectionDirective>());
+        }
+
+        [Fact]
+        public void ReadsMethodInjectorsFromPlan()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.planMock.Verify(x => x.GetAll<PropertyInjectionDirective>(), Times.Once());
+        }
+    }
+
+    public class WhenActivateIsCalled_WithoutProjectInjectionDirectivesAndWithPropertyValues : PropertyInjectionDirectiveContext
+    {
+        protected Dummy instance;
+        protected PropertyInfo fooProperty = typeof(Dummy).GetProperty("Foo");
+        protected PropertyInfo barProperty = typeof(Dummy).GetProperty("Bar");
+        protected int fooPropertyValue;
+        protected string barPropertyValue;
+        protected Mock<PropertyInjector> fooInjectorMock;
+        protected Mock<PropertyInjector> barInjectorMock;
+        protected InstanceReference reference;
+        protected PropertyInjectionDirective[] directives;
+        protected IEnumerable<IParameter> parameters;
+
+        public WhenActivateIsCalled_WithoutProjectInjectionDirectivesAndWithPropertyValues()
+        {
+            this.fooInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+            this.barInjectorMock = new Mock<PropertyInjector>(MockBehavior.Strict);
+
+            this.fooPropertyValue = new Random().Next();
+            this.barPropertyValue = new Random().Next().ToString();
+            this.parameters = new List<IParameter>
+                {
+                    new ConstructorArgument("A", "B"),
+                    new PropertyValue(this.fooProperty.Name, fooPropertyValue),
+                    new PropertyValue(this.barProperty.Name, barPropertyValue)
+                };
+            this.instance = new Dummy();
+            this.reference = new InstanceReference { Instance = this.instance };
+
+            var mockSequence = new MockSequence();
+
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(p => p.Parameters)
+                            .Returns(parameters);
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Plan)
+                            .Returns(this.planMock.Object);
+            this.planMock.InSequence(mockSequence)
+                         .Setup(x => x.GetAll<PropertyInjectionDirective>())
+                         .Returns(Enumerable.Empty<PropertyInjectionDirective>());
+            this.injectorFactoryMock.InSequence(mockSequence)
+                                    .Setup(p => p.Create(fooProperty))
+                                    .Returns(fooInjectorMock.Object);
+            this.fooInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, fooPropertyValue));
+            this.injectorFactoryMock.InSequence(mockSequence)
+                                    .Setup(p => p.Create(barProperty))
+                                    .Returns(barInjectorMock.Object);
+            this.barInjectorMock.InSequence(mockSequence)
+                                .Setup(p => p(this.instance, barPropertyValue));
+        }
+
+        [Fact]
+        public void ReadsMethodInjectorsFromPlan()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.planMock.Verify(x => x.GetAll<PropertyInjectionDirective>(), Times.Once());
+        }
+
+        [Fact]
+        public void InjectorIsInvokedForEachPropertyForWhilePropertyValueIsSupplied()
+        {
+            this.strategy.Activate(this.contextMock.Object, this.reference);
+
+            this.fooInjectorMock.Verify(x => x(this.instance, fooPropertyValue), Times.Once());
+            this.barInjectorMock.Verify(x => x(this.instance, barPropertyValue), Times.Once());
+        }
+    }
+
+    public class WhenActivateIsCalled_PropertyValueCannotBeResolvedToProperty : PropertyInjectionDirectiveContext
+    {
+        protected Mock<IRequest> requestMock;
+        protected Dummy instance;
+        protected InstanceReference reference;
+        private string exceptionMessage;
+        protected IEnumerable<IParameter> parameters;
+
+        public WhenActivateIsCalled_PropertyValueCannotBeResolvedToProperty()
+        {
+            this.requestMock = new Mock<IRequest>(MockBehavior.Strict);
+
+            this.parameters = new List<IParameter>
+                {
+                    new ConstructorArgument("A", "B"),
+                    new PropertyValue("DoesNotExist", "Boom!"),
+                };
+            this.instance = new Dummy();
+            this.reference = new InstanceReference { Instance = this.instance };
+            this.exceptionMessage = this.random.Next().ToString();
+
+            var mockSequence = new MockSequence();
+
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(p => p.Parameters)
+                            .Returns(parameters);
+            this.contextMock.InSequence(mockSequence)
+                            .SetupGet(x => x.Plan)
+                            .Returns(this.planMock.Object);
+            this.planMock.InSequence(mockSequence)
+                         .Setup(x => x.GetAll<PropertyInjectionDirective>())
+                         .Returns(Enumerable.Empty<PropertyInjectionDirective>());
+            this.contextMock.InSequence(mockSequence)
+                            .Setup(p => p.Request)
+                            .Returns(this.requestMock.Object);
+            this.exceptionFormatterMock.InSequence(mockSequence)
+                                       .Setup(p => p.CouldNotResolvePropertyForValueInjection(this.requestMock.Object, "DoesNotExist"))
+                                       .Returns(this.exceptionMessage);
+        }
+
+        [Fact]
+        public void ReadsMethodInjectorsFromPlan()
+        {
+            Assert.Throws<ActivationException>(() => this.strategy.Activate(this.contextMock.Object, this.reference));
+
+            this.planMock.Verify(x => x.GetAll<PropertyInjectionDirective>(), Times.Once());
+        }
+
+        [Fact]
+        public void ThrowsActivationException()
+        {
+            var actualException = Assert.Throws<ActivationException>(() => this.strategy.Activate(this.contextMock.Object, this.reference));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Same(this.exceptionMessage, actualException.Message);
+        }
+    }
+
+
+    public interface ITargetFactory
+    {
+        ITarget Create(PropertyInfo property);
     }
 
     public class FakePropertyInjectionDirective : PropertyInjectionDirective
     {
-        public Mock<ITarget> TargetMock { get; private set; }
+        public static ITargetFactory TargetFactory { get; set; }
 
         public FakePropertyInjectionDirective(PropertyInfo property, PropertyInjector injector)
-            : base(property, injector) { }
+            : base(property, injector) {
+        }
 
         protected override ITarget CreateTarget(PropertyInfo property)
         {
-            this.TargetMock = new Mock<ITarget>();
-            return this.TargetMock.Object;
+            return TargetFactory.Create(property);
         }
     }
 
@@ -102,5 +529,6 @@ namespace Ninject.Tests.Unit.PropertyInjectionStrategyTests
     {
         public int Foo { get; set; }
         public string Bar { get; set; }
+        public string Goo { get; set; }
     }
 }

--- a/src/Ninject/Activation/Strategies/PropertyInjectionStrategy.cs
+++ b/src/Ninject/Activation/Strategies/PropertyInjectionStrategy.cs
@@ -23,7 +23,6 @@ namespace Ninject.Activation.Strategies
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
 
     using Ninject.Components;
@@ -54,14 +53,21 @@ namespace Ninject.Activation.Strategies
         private readonly INinjectSettings settings;
 
         /// <summary>
+        /// The <see cref="IExceptionFormatter"/> component.
+        /// </summary>
+        private readonly IExceptionFormatter exceptionFormatter;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="PropertyInjectionStrategy"/> class.
         /// </summary>
         /// <param name="injectorFactory">The injector factory component.</param>
         /// <param name="settings">The ninject settings.</param>
-        public PropertyInjectionStrategy(IInjectorFactory injectorFactory, INinjectSettings settings)
+        /// <param name="exceptionFormatter">The <see cref="IExceptionFormatter"/> component.</param>
+        public PropertyInjectionStrategy(IInjectorFactory injectorFactory, INinjectSettings settings, IExceptionFormatter exceptionFormatter)
         {
             this.injectorFactory = injectorFactory;
             this.settings = settings;
+            this.exceptionFormatter = exceptionFormatter;
         }
 
         private BindingFlags Flags
@@ -83,7 +89,7 @@ namespace Ninject.Activation.Strategies
             Ensure.ArgumentNotNull(context, "context");
             Ensure.ArgumentNotNull(reference, "reference");
 
-            var propertyValues = context.Parameters.OfType<IPropertyValue>().ToList();
+            var propertyValues = GetPropertyValues(context.Parameters);
 
             foreach (var directive in context.Plan.GetAll<PropertyInjectionDirective>())
             {
@@ -91,7 +97,58 @@ namespace Ninject.Activation.Strategies
                 directive.Injector(reference.Instance, value);
             }
 
-            this.AssignPropertyOverrides(context, reference, propertyValues);
+            if (propertyValues.Count > 0)
+            {
+                this.AssignPropertyOverrides(context, reference, propertyValues);
+            }
+        }
+
+        /// <summary>
+        /// Locates a <see cref="PropertyInfo"/> by name using the specified <see cref="StringComparison"/>.
+        /// </summary>
+        /// <param name="properties">The list of properties to search.</param>
+        /// <param name="name">The name to find.</param>
+        /// <param name="stringComparison">The <see cref="StringComparison"/> to use when comparing the name.</param>
+        /// <returns>
+        /// The <see cref="PropertyInfo"/> with a matching <see cref="IParameter.Name"/>, if found; otherwise,
+        /// <see langword="null"/>.
+        /// </returns>
+        private static PropertyInfo FindPropertyByName(PropertyInfo[] properties, string name, StringComparison stringComparison)
+        {
+            PropertyInfo found = null;
+
+            foreach (var property in properties)
+            {
+                if (string.Equals(property.Name, name, stringComparison))
+                {
+                    found = property;
+                    break;
+                }
+            }
+
+            return found;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="IPropertyValue"/> instances in the specified parameters.
+        /// </summary>
+        /// <param name="parameters">The parameters to search.</param>
+        /// <returns>
+        /// A list of the <see cref="IPropertyValue"/> instances in <paramref name="parameters"/>.
+        /// </returns>
+        private static List<IPropertyValue> GetPropertyValues(IEnumerable<IParameter> parameters)
+        {
+            var propertyValues = new List<IPropertyValue>();
+
+            foreach (var parameter in parameters)
+            {
+                if (parameter is IPropertyValue propertyValue)
+                {
+                    propertyValues.Add(propertyValue);
+                }
+            }
+
+            return propertyValues;
         }
 
         /// <summary>
@@ -100,22 +157,21 @@ namespace Ninject.Activation.Strategies
         /// <param name="context">The context.</param>
         /// <param name="reference">A reference to the instance being activated.</param>
         /// <param name="propertyValues">The parameter override value accessors.</param>
-        private void AssignPropertyOverrides(IContext context, InstanceReference reference, IList<IPropertyValue> propertyValues)
+        private void AssignPropertyOverrides(IContext context, InstanceReference reference, List<IPropertyValue> propertyValues)
         {
             var properties = reference.Instance.GetType().GetProperties(this.Flags);
 
             foreach (var propertyValue in propertyValues)
             {
-                var propertyName = propertyValue.Name;
-                var propertyInfo = properties.FirstOrDefault(property => string.Equals(property.Name, propertyName, StringComparison.Ordinal));
+                var propertyInfo = FindPropertyByName(properties, propertyValue.Name, StringComparison.Ordinal);
 
                 if (propertyInfo == null)
                 {
-                    throw new ActivationException(ExceptionFormatter.CouldNotResolvePropertyForValueInjection(context.Request, propertyName));
+                    throw new ActivationException(this.exceptionFormatter.CouldNotResolvePropertyForValueInjection(context.Request, propertyValue.Name));
                 }
 
                 var target = new PropertyInjectionDirective(propertyInfo, this.injectorFactory.Create(propertyInfo));
-                var value = this.GetValue(context, target.Target, propertyValues);
+                var value = propertyValue.GetValue(context, target.Target);
                 target.Injector(reference.Instance, value);
             }
         }
@@ -125,15 +181,49 @@ namespace Ninject.Activation.Strategies
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="target">The target.</param>
-        /// <param name="allPropertyValues">all property values of the current request.</param>
-        /// <returns>The value to inject into the specified target.</returns>
-        private object GetValue(IContext context, ITarget target, IEnumerable<IPropertyValue> allPropertyValues)
+        /// <param name="allPropertyValues">The property values of the current request.</param>
+        /// <returns>
+        /// The value to inject into the specified <see cref="ITarget"/>.
+        /// </returns>
+        private object GetValue(IContext context, ITarget target, List<IPropertyValue> allPropertyValues)
         {
-            Ensure.ArgumentNotNull(context, "context");
-            Ensure.ArgumentNotNull(target, "target");
+            var parameter = this.FindPropertyValueByName(context, allPropertyValues, target.Name, StringComparison.Ordinal);
+            if (parameter != null)
+            {
+                // Remove parameter from list of property values to ensure we do not attempt to process
+                // it again when we assign the overrides.
+                allPropertyValues.Remove(parameter);
+                return parameter.GetValue(context, target);
+            }
 
-            var parameter = allPropertyValues.SingleOrDefault(p => p.Name == target.Name);
-            return parameter != null ? parameter.GetValue(context, target) : target.ResolveWithin(context);
+            return target.ResolveWithin(context);
+        }
+
+        /// <summary>
+        /// Locates a <see cref="IPropertyValue"/> by name using the specified <see cref="StringComparison"/>.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="propertyValues">The list of property values to search.</param>
+        /// <param name="name">The name to find.</param>
+        /// <param name="stringComparison">The <see cref="StringComparison"/> to use when comparing the name.</param>
+        /// <returns>
+        /// The <see cref="IPropertyValue"/> with a matching <see cref="IParameter.Name"/>, if found; otherwise,
+        /// <see langword="null"/>.
+        /// </returns>
+        private IPropertyValue FindPropertyValueByName(IContext context, List<IPropertyValue> propertyValues, string name, StringComparison stringComparison)
+        {
+            IPropertyValue found = null;
+
+            foreach (var propertyValue in propertyValues)
+            {
+                if (string.Equals(propertyValue.Name, name, stringComparison))
+                {
+                    found = propertyValue;
+                    break;
+                }
+            }
+
+            return found;
         }
     }
 }

--- a/src/Ninject/Components/ExceptionFormatter.cs
+++ b/src/Ninject/Components/ExceptionFormatter.cs
@@ -176,29 +176,6 @@ namespace Ninject.Components
         }
 
         /// <summary>
-        /// Generates a message saying that the specified property could not be resolved on the specified request.
-        /// </summary>
-        /// <param name="request">The request.</param>
-        /// <param name="propertyName">The property name.</param>
-        /// <returns>The exception message.</returns>
-        public static string CouldNotResolvePropertyForValueInjection(IRequest request, string propertyName)
-        {
-            using (var sw = new StringWriter())
-            {
-                sw.WriteLine("Error activating {0}", request.Service.Format());
-                sw.WriteLine("No matching property {0}.", propertyName);
-
-                sw.WriteLine("Activation path:");
-                sw.WriteLine(request.FormatActivationPath());
-
-                sw.WriteLine("Suggestions:");
-                sw.WriteLine("  1) Ensure that you have the correct property name.");
-
-                return sw.ToString();
-            }
-        }
-
-        /// <summary>
         /// Generates a message saying that the provider callback on the specified context is null.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -274,6 +251,29 @@ namespace Ninject.Components
                 sw.WriteLine("  3) Ensure you have not accidentally created more than one kernel.");
                 sw.WriteLine("  4) If you are using constructor arguments, ensure that the parameter name matches the constructors parameter name.");
                 sw.WriteLine("  5) If you are using automatic module loading, ensure the search path and filters are correct.");
+
+                return sw.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Generates a message saying that the specified property could not be resolved on the specified request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="propertyName">The property name.</param>
+        /// <returns>The exception message.</returns>
+        public string CouldNotResolvePropertyForValueInjection(IRequest request, string propertyName)
+        {
+            using (var sw = new StringWriter())
+            {
+                sw.WriteLine("Error activating {0}", request.Service.Format());
+                sw.WriteLine("No matching property {0}.", propertyName);
+
+                sw.WriteLine("Activation path:");
+                sw.WriteLine(request.FormatActivationPath());
+
+                sw.WriteLine("Suggestions:");
+                sw.WriteLine("  1) Ensure that you have the correct property name.");
 
                 return sw.ToString();
             }

--- a/src/Ninject/Components/IExceptionFormatter.cs
+++ b/src/Ninject/Components/IExceptionFormatter.cs
@@ -24,6 +24,7 @@ namespace Ninject.Components
     using System;
 
     using Ninject.Activation;
+    using Ninject.Parameters;
 
     /// <summary>
     /// Provides meaningful exception messages.
@@ -36,6 +37,14 @@ namespace Ninject.Components
         /// <param name="request">The request.</param>
         /// <returns>The exception message.</returns>
         string CouldNotResolveBinding(IRequest request);
+
+        /// <summary>
+        /// Generates a message saying that the specified property could not be resolved on the specified request.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="propertyName">The property name.</param>
+        /// <returns>The exception message.</returns>
+        string CouldNotResolvePropertyForValueInjection(IRequest request, string propertyName);
 
         /// <summary>
         /// Generates a message saying that the specified context has cyclic dependencies.


### PR DESCRIPTION
* Improves performance and reduce allocations for **PropertyInjectionStrategy**.
* Use **(I)ExceptionFormatter** as component in **PropertyInjectionStrategy**.

**Before:**

|                                                                      Method |         Mean |        Error |       StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
----------------------------------------------------------------------------- |-------------:|-------------:|-------------:|------------:|------------:|------------:|--------------------:|
|    Activate_WithoutPropertyInjectionDirectivesAndWithPropertyValuesFullMatch | 276,960.0 ns | 1,659.527 ns | 1,471.128 ns |      3.9063 |      1.9531 |           - |             17481 B |
| Activate_WithoutPropertyInjectionDirectivesAndWithPropertyValuesPartialMatch | 187,869.7 ns | 1,512.608 ns | 1,340.887 ns |      2.6855 |      1.2207 |           - |             11880 B |
|          Activate_WithoutPropertyInjectionDirectivesAndWithoutPropertyValues |     358.7 ns |     3.609 ns |     3.376 ns |      0.0815 |           - |           - |               344 B |
|       Activate_WithPropertyInjectionDirectivesAndWithPropertyValuesFullMatch | 277,636.6 ns | 1,941.910 ns | 1,816.464 ns |      3.9063 |      1.9531 |           - |             17865 B |
|    Activate_WithPropertyInjectionDirectivesAndWithPropertyValuesPartialMatch | 194,956.4 ns | 1,258.220 ns | 1,176.940 ns |      3.1738 |      1.4648 |           - |             14121 B |
|             Activate_WithPropertyInjectionDirectivesAndWithoutPropertyValues |   6,240.7 ns |    49.278 ns |    46.095 ns |      1.2970 |           - |           - |              5456 B |             

**After:**

|                                                                      Method |         Mean |        Error |       StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
----------------------------------------------------------------------------- |-------------:|-------------:|-------------:|------------:|------------:|------------:|--------------------:|
|    Activate_WithoutPropertyInjectionDirectivesAndWithPropertyValuesFullMatch | 263,434.6 ns | 3,778.842 ns | 3,534.731 ns |      3.9063 |      1.9531 |           - |             16641 B |
 Activate_WithoutPropertyInjectionDirectivesAndWithPropertyValuesPartialMatch | 172,033.5 ns | 1,559.241 ns | 1,382.226 ns |      2.6855 |      1.2207 |           - |             11288 B |
|          Activate_WithoutPropertyInjectionDirectivesAndWithoutPropertyValues |     127.9 ns |     1.475 ns |     1.231 ns |      0.0477 |           - |           - |               200 B |
|       Activate_WithPropertyInjectionDirectivesAndWithPropertyValuesFullMatch |     746.4 ns |     7.429 ns |     6.585 ns |      0.1268 |           - |           - |               536 B |
|    Activate_WithPropertyInjectionDirectivesAndWithPropertyValuesPartialMatch |   2,638.4 ns |    27.124 ns |    24.044 ns |      0.5379 |           - |           - |              2264 B |
|             Activate_WithPropertyInjectionDirectivesAndWithoutPropertyValues |   4,963.3 ns |    53.652 ns |    50.186 ns |      1.0757 |           - |           - |              4544 B |

