### PR TITLE
Use reference equality comparer for Type-based keys

### DIFF
--- a/src/Ninject.Benchmarks/Infrastructure/ReferenceEqualityTypeComparerBenchmark.cs
+++ b/src/Ninject.Benchmarks/Infrastructure/ReferenceEqualityTypeComparerBenchmark.cs
@@ -1,0 +1,125 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ninject.Infrastructure;
+using System;
+using System.Collections.Generic;
+
+namespace Ninject.Benchmarks.Infrastructure
+{
+    public class ReferenceEqualityTypeComparerBenchmark
+    {
+        private ReferenceEqualityTypeComparer _refEqualityComparer;
+        private EqualityComparer<Type> _defaultComparer;
+        private Dictionary<Type, string> _refEqualityDictionary;
+        private Dictionary<Type, string> _defaultDictionary;
+        private Type _bclType;
+        private Type _ninjectType;
+
+        public ReferenceEqualityTypeComparerBenchmark()
+        {
+            _refEqualityComparer = new ReferenceEqualityTypeComparer();
+            _defaultComparer = EqualityComparer<Type>.Default;
+
+            _refEqualityDictionary = new Dictionary<Type, string>(_refEqualityComparer);
+            _defaultDictionary = new Dictionary<Type, string>();
+
+            foreach (var t in typeof(string).Assembly.GetTypes())
+            {
+                _refEqualityDictionary[t] = t.FullName;
+                _defaultDictionary[t] = t.FullName;
+            }
+
+            _bclType = typeof(string);
+            _ninjectType = GetType();
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void DictionaryLookup_Match_ReferenceEquality()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _refEqualityDictionary.ContainsKey(_bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void DictionaryLookup_Match_Default()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _defaultDictionary.ContainsKey(_bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void DictionaryLookup_NoMatch_ReferenceEquality()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _refEqualityDictionary.ContainsKey(_ninjectType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void DictionaryLookup_NoMatch_Default()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _defaultDictionary.ContainsKey(_ninjectType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void GetHashCode_ReferenceEquality()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _refEqualityComparer.GetHashCode(_bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void GetHashCode_Default()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _defaultComparer.GetHashCode(_bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void EqualsInstancesTheSame_ReferenceEquality()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _refEqualityComparer.Equals(_bclType, _bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void EqualsInstancesTheSame_Default()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _defaultComparer.Equals(_bclType, _bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void EqualsInstancesNotTheSame_ReferenceEquality()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _refEqualityComparer.Equals(_ninjectType, _bclType);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 1000)]
+        public void EqualsInstancesNotTheSame_Default()
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                _defaultComparer.Equals(_ninjectType, _bclType);
+            }
+        }
+    }
+}

--- a/src/Ninject.Benchmarks/ReadOnlyKernelBenchmark.cs
+++ b/src/Ninject.Benchmarks/ReadOnlyKernelBenchmark.cs
@@ -50,6 +50,17 @@ namespace Ninject.Benchmarks
         }
 
         [Benchmark]
+        public void GetBindings_FromCache()
+        {
+            var bindings = _readOnlyKernel.GetBindings(typeof(ICleric));
+            foreach (var binding in bindings)
+            {
+                if (binding.Service == null)
+                    throw new Exception();
+            }
+        }
+
+        [Benchmark]
         public void GetBindings_SingleResult()
         {
             var bindings = _readOnlyKernel.GetBindings(typeof(ICleric));

--- a/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForDictionaryTests.cs
+++ b/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForDictionaryTests.cs
@@ -11,7 +11,7 @@ namespace Ninject.Test.Unit.Infrastructure.Language
     public class ExtensionsForDictionaryTests
     {
         [Fact]
-        public void CloneShouldMakeCopyOfValues()
+        public void Clone_Dictionary_ShouldMakeCopyOfValues()
         {
             const string valueA = "A";
             const string valueB = "B";
@@ -54,11 +54,130 @@ namespace Ninject.Test.Unit.Infrastructure.Language
         }
 
         [Fact]
-        public void CloneShouldThrowNullReferenceExceptionWhenDictionaryIsNull()
+        public void Clone_Dictionary_ShouldThrowNullReferenceExceptionWhenDictionaryIsNull()
         {
             Dictionary<string, ICollection<int>> dictionary = null;
 
             Assert.Throws<NullReferenceException>(() => dictionary.Clone());
+        }
+
+        [Fact]
+        public void Clone_DictionaryAndComparer_ShouldMakeCopyOfValues()
+        {
+            const string valueA = "A";
+            const string valueB = "B";
+            var list1 = new List<string> { valueA, valueB };
+            var list2 = new List<string> { valueB, valueA };
+            var list3 = new List<string>();
+
+            var source = new Dictionary<int, ICollection<string>>
+                {
+                    { 1, list1 },
+                    { 2, list2 },
+                    { 3, list3 },
+                };
+
+            var clone = source.Clone();
+
+            Assert.NotNull(clone);
+            Assert.Equal(source.Count, clone.Count);
+
+            Assert.True(clone.ContainsKey(1));
+            var clonedCollection1 = clone[1];
+            Assert.NotSame(list1, clonedCollection1);
+            Assert.Equal(2, clonedCollection1.Count);
+            var clonedList1 = clonedCollection1.ToList();
+            Assert.Same(valueA, clonedList1[0]);
+            Assert.Same(valueB, clonedList1[1]);
+
+            Assert.True(clone.ContainsKey(2));
+            var clonedCollection2 = clone[2];
+            Assert.NotSame(list2, clonedCollection2);
+            Assert.Equal(2, clonedCollection2.Count);
+            var clonedList2 = clonedCollection2.ToList();
+            Assert.Same(valueB, clonedList2[0]);
+            Assert.Same(valueA, clonedList2[1]);
+
+            Assert.True(clone.ContainsKey(3));
+            var clonedCollection3 = clone[3];
+            Assert.NotSame(list3, clonedCollection3);
+            Assert.Equal(0, clonedCollection3.Count);
+        }
+
+        [Fact]
+        public void Clone_DictionaryAndComparer_ShouldUseComparer()
+        {
+            var valueA = new List<string> { "ValueA", "Valuea" };
+            var valueB = new List<string> { "Valueb", "ValueB" };
+
+            var source = new Dictionary<string, ICollection<string>>
+                {
+                    { "A", valueA },
+                    { "B", valueB },
+                };
+
+            var clone = source.Clone(new OrdinalIgnoreCaseComparer());
+
+            Assert.NotNull(clone);
+            Assert.Equal(source.Count, clone.Count);
+
+            Assert.True(clone.ContainsKey("b"));
+            Assert.Equal(valueA, clone["a"]);
+
+            var newValueA = new List<string> { "newValueA" };
+            clone["a"] = newValueA;
+
+            Assert.Equal(2, clone.Count);
+            Assert.Same(newValueA, clone["A"]);
+            Assert.Same(newValueA, clone["a"]);
+        }
+
+        [Fact]
+        public void Clone_DictionaryAndComparer_ShouldUseDefaultEqualityComparerWhenComparerIsNull()
+        {
+            var valueA = new List<string> { "ValueA", "Valuea" };
+            var valueB = new List<string> { "Valueb", "ValueB" };
+
+            var source = new Dictionary<string, ICollection<string>>
+                {
+                    { "A", valueA },
+                    { "B", valueB },
+                };
+
+            var clone = source.Clone(null);
+
+            Assert.NotNull(clone);
+            Assert.Equal(source.Count, clone.Count);
+
+            Assert.False(clone.ContainsKey("b"));
+
+            var newValueA = new List<string> { "newValueA" };
+            clone["a"] = newValueA;
+
+            Assert.Equal(3, clone.Count);
+            Assert.Equal(valueA, clone["A"]);
+            Assert.Same(newValueA, clone["a"]);
+        }
+
+        [Fact]
+        public void Clone_DictionaryAndComparer_ShouldThrowNullReferenceExceptionWhenDictionaryIsNull()
+        {
+            Dictionary<string, ICollection<int>> dictionary = null;
+
+            Assert.Throws<NullReferenceException>(() => dictionary.Clone());
+        }
+
+        private class OrdinalIgnoreCaseComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string x, string y)
+            {
+                return string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(string obj)
+            {
+                return obj.ToUpperInvariant().GetHashCode();
+            }
         }
     }
 }

--- a/src/Ninject/Components/ComponentContainer.cs
+++ b/src/Ninject/Components/ComponentContainer.cs
@@ -38,7 +38,7 @@ namespace Ninject.Components
         /// <summary>
         /// The mappings for ninject components.
         /// </summary>
-        private readonly Multimap<Type, Type> mappings = new Multimap<Type, Type>();
+        private readonly Multimap<Type, Type> mappings = new Multimap<Type, Type>(new ReferenceEqualityTypeComparer());
 
         /// <summary>
         /// The mappings for ninject components with transient scope.
@@ -48,7 +48,7 @@ namespace Ninject.Components
         /// <summary>
         /// The ninject component instances.
         /// </summary>
-        private readonly Dictionary<Type, INinjectComponent> instances = new Dictionary<Type, INinjectComponent>();
+        private readonly Dictionary<Type, INinjectComponent> instances = new Dictionary<Type, INinjectComponent>(new ReferenceEqualityTypeComparer());
 
         /// <summary>
         /// The ninject settings.

--- a/src/Ninject/GlobalKernelRegistration.cs
+++ b/src/Ninject/GlobalKernelRegistration.cs
@@ -26,6 +26,8 @@ namespace Ninject
     using System.Linq;
     using System.Threading;
 
+    using Ninject.Infrastructure;
+
     /// <summary>
     /// Allows to register kernel globally to perform some tasks on all kernels.
     /// The registration is done by loading the GlobalKernelRegistrationModule to the kernel.
@@ -34,7 +36,7 @@ namespace Ninject
     {
         private static readonly ReaderWriterLockSlim KernelRegistrationsLock = new ReaderWriterLockSlim();
 
-        private static readonly IDictionary<Type, Registration> KernelRegistrations = new Dictionary<Type, Registration>();
+        private static readonly IDictionary<Type, Registration> KernelRegistrations = new Dictionary<Type, Registration>(new ReferenceEqualityTypeComparer());
 
         /// <summary>
         /// Registers the kernel for the specified type.

--- a/src/Ninject/Infrastructure/Language/ExtensionsForDictionary.cs
+++ b/src/Ninject/Infrastructure/Language/ExtensionsForDictionary.cs
@@ -71,10 +71,35 @@ namespace Ninject.Infrastructure.Language
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <typeparam name="TValue">The type of the value item.</typeparam>
         /// <param name="dictionary">The dictionary to clone.</param>
-        /// <returns>The cloned dictionary.</returns>
+        /// <returns>
+        /// The cloned dictionary.
+        /// </returns>
         public static Dictionary<TKey, ICollection<TValue>> Clone<TKey, TValue>(this Dictionary<TKey, ICollection<TValue>> dictionary)
         {
             var clonedDictionary = new Dictionary<TKey, ICollection<TValue>>(dictionary.Count);
+
+            foreach (var kvp in dictionary)
+            {
+                // Add the entry with a clone of the values
+                clonedDictionary.Add(kvp.Key, kvp.Value.ToList());
+            }
+
+            return clonedDictionary;
+        }
+
+        /// <summary>
+        /// Clones the dictionary, and the list of values for each entry.
+        /// </summary>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value item.</typeparam>
+        /// <param name="dictionary">The dictionary to clone.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys, or <see langword="null"/> to use the default <see cref="EqualityComparer{T}"/> for the type of the key.</param>
+        /// <returns>
+        /// The cloned dictionary.
+        /// </returns>
+        public static Dictionary<TKey, ICollection<TValue>> Clone<TKey, TValue>(this Dictionary<TKey, ICollection<TValue>> dictionary, IEqualityComparer<TKey> comparer)
+        {
+            var clonedDictionary = new Dictionary<TKey, ICollection<TValue>>(dictionary.Count, comparer);
 
             foreach (var kvp in dictionary)
             {

--- a/src/Ninject/Infrastructure/Multimap.cs
+++ b/src/Ninject/Infrastructure/Multimap.cs
@@ -32,7 +32,26 @@ namespace Ninject.Infrastructure
     /// <typeparam name="TValue">The type of value.</typeparam>
     public class Multimap<TKey, TValue> : IEnumerable<KeyValuePair<TKey, IList<TValue>>>
     {
-        private readonly Dictionary<TKey, IList<TValue>> items = new Dictionary<TKey, IList<TValue>>();
+        private readonly Dictionary<TKey, IList<TValue>> items;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Multimap{TKey, TValue}"/> class that is empty,
+        /// has the default initial capacity, and uses the default <see cref="IEqualityComparer{T}"/>.
+        /// </summary>
+        public Multimap()
+        {
+            this.items = new Dictionary<TKey, IList<TValue>>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Multimap{TKey, TValue}"/> class that is empty,
+        /// has the default initial capacity, and uses the specified <see cref="IEqualityComparer{T}"/>.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys, or <see langword="null"/> to use the default <see cref="EqualityComparer{T}"/> for the type of the key.</param>
+        public Multimap(IEqualityComparer<TKey> comparer)
+        {
+            this.items = new Dictionary<TKey, IList<TValue>>(comparer);
+        }
 
         /// <summary>
         /// Gets the collection of keys.

--- a/src/Ninject/Infrastructure/ReferenceEqualityTypeComparer.cs
+++ b/src/Ninject/Infrastructure/ReferenceEqualityTypeComparer.cs
@@ -1,0 +1,61 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ReferenceEqualityTypeComparer.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2007-2010 Enkari, Ltd. All rights reserved.
+//   Copyright (c) 2010-2017 Ninject Project Contributors. All rights reserved.
+//
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   You may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace Ninject.Infrastructure
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// An <see cref="IEqualityComparer{Type}"/> that considers two instances equal when they are
+    /// the same instances.
+    /// </summary>
+    public sealed class ReferenceEqualityTypeComparer : IEqualityComparer<Type>
+    {
+        /// <summary>
+        /// Determines whether the specified instances are the same instance.
+        /// </summary>
+        /// <param name="x">The first instance to compare.</param>
+        /// <param name="y">The second instance to compare.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="x"/> is the same instance as <paramref name="y"/> or
+        /// if both are <see langword="null"/>; otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool Equals(Type x, Type y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        /// <summary>
+        /// Returns a hash code for the specified <see cref="Type"/>.
+        /// </summary>
+        /// <param name="obj">The instance for which a hash code is to be returned.</param>
+        /// <returns>
+        /// A hash code for <paramref name="obj"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="obj"/> is <see langword="null"/>.</exception>
+        public int GetHashCode(Type obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/src/Ninject/KernelBase.cs
+++ b/src/Ninject/KernelBase.cs
@@ -295,8 +295,11 @@ namespace Ninject
         /// until a consumer iterates over the enumerator.
         /// </summary>
         /// <param name="request">The request to resolve.</param>
-        /// <returns>An enumerator of instances that match the request.</returns>
+        /// <returns>
+        /// An enumerator of instances that match the request.
+        /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ActivationException">More than one matching bindings is available for the request, and <see cref="IRequest.IsUnique"/> is <see langword="true"/>.</exception>
         public virtual IEnumerable<object> Resolve(IRequest request)
         {
             return this.ReadOnlyKernel.Resolve(request);

--- a/src/Ninject/KernelConfiguration.cs
+++ b/src/Ninject/KernelConfiguration.cs
@@ -50,7 +50,7 @@ namespace Ninject
         /// <summary>
         /// The service-bindings dictionary.
         /// </summary>
-        private readonly Dictionary<Type, ICollection<IBinding>> bindings = new Dictionary<Type, ICollection<IBinding>>();
+        private readonly Dictionary<Type, ICollection<IBinding>> bindings = new Dictionary<Type, ICollection<IBinding>>(new ReferenceEqualityTypeComparer());
 
         /// <summary>
         /// The ninject modules.
@@ -261,9 +261,8 @@ namespace Ninject
 
             var resolvers = this.Components.GetAll<IBindingResolver>();
 
-            return resolvers.SelectMany(resolver => resolver.Resolve(
-                this.bindings.Keys.ToDictionary(type => type, type => this.bindings[type]),
-                service)).ToArray();
+            return resolvers.SelectMany(resolver => resolver.Resolve(new Dictionary<Type, ICollection<IBinding>>(this.bindings, new ReferenceEqualityTypeComparer()), service))
+                            .ToArray();
         }
 
         /// <summary>
@@ -274,7 +273,7 @@ namespace Ninject
         {
             var readonlyKernel = new ReadOnlyKernel(
                 this.Settings,
-                this.bindings.Clone(),
+                this.bindings,
                 this.Components.Get<ICache>(),
                 this.Components.Get<IPlanner>(),
                 this.Components.Get<IConstructorScorer>(),

--- a/src/Ninject/KernelConfiguration.cs
+++ b/src/Ninject/KernelConfiguration.cs
@@ -273,7 +273,7 @@ namespace Ninject
         {
             var readonlyKernel = new ReadOnlyKernel(
                 this.Settings,
-                this.bindings,
+                this.bindings.Clone(new ReferenceEqualityTypeComparer()),
                 this.Components.Get<ICache>(),
                 this.Components.Get<IPlanner>(),
                 this.Components.Get<IConstructorScorer>(),

--- a/src/Ninject/Planning/Planner.cs
+++ b/src/Ninject/Planning/Planner.cs
@@ -36,7 +36,7 @@ namespace Ninject.Planning
     public class Planner : NinjectComponent, IPlanner
     {
         private readonly ReaderWriterLockSlim plannerLock = new ReaderWriterLockSlim();
-        private readonly Dictionary<Type, IPlan> plans = new Dictionary<Type, IPlan>();
+        private readonly Dictionary<Type, IPlan> plans = new Dictionary<Type, IPlan>(new ReferenceEqualityTypeComparer());
         private readonly List<IPlanningStrategy> strategies;
 
         /// <summary>

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -84,7 +84,7 @@ namespace Ninject
             IEnumerable<IMissingBindingResolver> missingBindingResolvers)
         {
             this.settings = settings;
-            this.bindings = new Dictionary<Type, ICollection<IBinding>>(bindings, new ReferenceEqualityTypeComparer());
+            this.bindings = bindings;
             this.bindingResolvers = bindingResolvers;
             this.missingBindingResolvers = missingBindingResolvers;
             this.cache = cache;
@@ -94,8 +94,8 @@ namespace Ninject
             this.exceptionFormatter = exceptionFormatter;
             this.bindingPrecedenceComparer = bindingPrecedenceComparer;
 
-            this.AddReadOnlyKernelBinding<IReadOnlyKernel>(this, this.bindings);
-            this.AddReadOnlyKernelBinding<IResolutionRoot>(this, this.bindings);
+            this.AddReadOnlyKernelBinding<IReadOnlyKernel>(this, bindings);
+            this.AddReadOnlyKernelBinding<IResolutionRoot>(this, bindings);
         }
 
         /// <summary>


### PR DESCRIPTION
Improves performance of dictionaries with a type-based key by using a reference equality comparer.

**Result:**

|                                      Method |       Mean |     Error |    StdDev |
|-------------------------------------------- |-----------:|----------:|----------:|
|    DictionaryLookup_Match_ReferenceEquality | 11.0069 ns | 0.0251 ns | 0.0235 ns |
|              DictionaryLookup_Match_Default | 13.0641 ns | 0.0165 ns | 0.0138 ns |
|  DictionaryLookup_NoMatch_ReferenceEquality | 13.4028 ns | 0.0572 ns | 0.0478 ns |
|            DictionaryLookup_NoMatch_Default | 12.9323 ns | 0.0274 ns | 0.0229 ns |
|               GetHashCode_ReferenceEquality |  1.4412 ns | 0.0023 ns | 0.0021 ns |
|                         GetHashCode_Default |  3.5885 ns | 0.0029 ns | 0.0026 ns |
|    EqualsInstancesTheSame_ReferenceEquality |  0.2457 ns | 0.0004 ns | 0.0003 ns |
|              EqualsInstancesTheSame_Default |  2.4295 ns | 0.0028 ns | 0.0025 ns |
| EqualsInstancesNotTheSame_ReferenceEquality |  0.2491 ns | 0.0007 ns | 0.0006 ns |
|           EqualsInstancesNotTheSame_Default |  2.5600 ns | 0.0047 ns | 0.0044 ns |
