### PR TITLE
Improve performance and reduce allocations of Cache

### DIFF
--- a/src/Ninject.Benchmarks/Activation/Caching/CacheBenchmark.cs
+++ b/src/Ninject.Benchmarks/Activation/Caching/CacheBenchmark.cs
@@ -1,0 +1,329 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ninject.Activation;
+using Ninject.Activation.Caching;
+using Ninject.Activation.Strategies;
+using Ninject.Components;
+using Ninject.Parameters;
+using Ninject.Planning;
+using Ninject.Planning.Bindings;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Ninject.Benchmarks.Activation.Caching
+{
+    [MemoryDiagnoser]
+    public class CacheBenchmark
+    {
+        private const int PerThreadLoopCount = 5_000;
+        private const int ThreadCount = 20;
+        private const int TryGetOperationsPerInvoke = 1000;
+
+        private Cache _cache;
+        private KernelConfiguration _kernelConfiguration;
+        private IReadOnlyKernel _readOnlyKernel;
+        private object _instanceForScopeWithZeroEntries;
+        private InstanceReference _instanceReferenceForScopeWithZeroEntries;
+        private Context _contextWithNoCache;
+        private Context _contextWithZeroEntriesForBindingConfiguration;
+        private Context _contextWithOneEntryForBindingConfiguration;
+        private Context _contextWithMoreThanOneEntryForBindingConfiguration;
+        private object _scopeWithNoCache;
+        private object _scopeWithOneEntryForBindingConfiguration;
+        private object _scopeWithMoreThanOneEntryForBindingConfiguration;
+        private object _scopeWithZeroEntriesForBindingConfiguration;
+
+        public CacheBenchmark()
+        {
+            var ninjectSettings = new NinjectSettings
+                {
+                    // Disable to reduce memory pressure
+                    ActivationCacheDisabled = true,
+                    LoadExtensions = false,
+                };
+
+            _cache = new Cache(new Pipeline(Enumerable.Empty<IActivationStrategy>(), new ActivationCache(new NoOpCachePruner())), new NoOpCachePruner());
+
+            _kernelConfiguration = new KernelConfiguration();
+            _readOnlyKernel = _kernelConfiguration.BuildReadOnlyKernel();
+            _instanceForScopeWithZeroEntries = new object();
+            _instanceReferenceForScopeWithZeroEntries = new InstanceReference { Instance = _instanceForScopeWithZeroEntries };
+
+            _scopeWithNoCache = new object();
+            _scopeWithOneEntryForBindingConfiguration = new object();
+            _scopeWithZeroEntriesForBindingConfiguration = new object();
+            _scopeWithMoreThanOneEntryForBindingConfiguration = new object();
+
+            _contextWithNoCache = CreateContext(_kernelConfiguration, _readOnlyKernel, typeof(string), _scopeWithNoCache, ninjectSettings);
+            _contextWithZeroEntriesForBindingConfiguration = CreateContext(_kernelConfiguration, _readOnlyKernel, typeof(string), _scopeWithZeroEntriesForBindingConfiguration, ninjectSettings);
+            _contextWithOneEntryForBindingConfiguration = CreateContext(_kernelConfiguration, _readOnlyKernel, typeof(string), _scopeWithOneEntryForBindingConfiguration, ninjectSettings);
+            _contextWithMoreThanOneEntryForBindingConfiguration = CreateContext(_kernelConfiguration, _readOnlyKernel, typeof(string), _scopeWithMoreThanOneEntryForBindingConfiguration, ninjectSettings);
+        }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _cache.Remember(_contextWithOneEntryForBindingConfiguration, _scopeWithOneEntryForBindingConfiguration, new InstanceReference { Instance = new object() });
+
+            _cache.Remember(_contextWithZeroEntriesForBindingConfiguration, _scopeWithZeroEntriesForBindingConfiguration, _instanceReferenceForScopeWithZeroEntries);
+            _cache.Release(_instanceForScopeWithZeroEntries);
+
+            _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, _scopeWithMoreThanOneEntryForBindingConfiguration, new InstanceReference { Instance = new object() });
+            _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, _scopeWithMoreThanOneEntryForBindingConfiguration, new InstanceReference { Instance = new object() });
+            _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, _scopeWithMoreThanOneEntryForBindingConfiguration, new InstanceReference { Instance = new object() });
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _cache.Clear();
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_Context_NoCacheForScope()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithNoCache);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_Context_OneEntryForBindingConfiguration()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithOneEntryForBindingConfiguration);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_Context_ZeroEntriesForBindingConfiguration()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithZeroEntriesForBindingConfiguration);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_Context_MoreThanOneEntryForBindingConfiguration()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithMoreThanOneEntryForBindingConfiguration);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke= TryGetOperationsPerInvoke)]
+        public void TryGet_ContextAndScope_NoCacheForScope()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithNoCache, _scopeWithNoCache);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_ContextAndScope_OneEntryForBindingConfiguration()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithOneEntryForBindingConfiguration, _scopeWithOneEntryForBindingConfiguration);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_ContextAndScope_ZeroEntriesForBindingConfiguration()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithZeroEntriesForBindingConfiguration, _scopeWithZeroEntriesForBindingConfiguration);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void TryGet_ContextAndScope_MoreThanOneEntryForBindingConfiguration()
+        {
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.TryGet(_contextWithMoreThanOneEntryForBindingConfiguration, _scopeWithMoreThanOneEntryForBindingConfiguration);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void Remember_ContextAndReference_NoCacheForScope()
+        {
+            var instance = new object();
+            var reference = new InstanceReference { Instance = instance };
+
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.Remember(_contextWithNoCache, reference);
+                _cache.Clear(_scopeWithNoCache);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void Remember_ContextAndScopeAndReference_NoCacheForScope()
+        {
+            var instance = new object();
+            var reference = new InstanceReference { Instance = instance };
+
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.Remember(_contextWithNoCache, _scopeWithNoCache, reference);
+                _cache.Clear(_scopeWithNoCache);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void Remember_ContextAndReference()
+        {
+            var instance = new object();
+            var reference = new InstanceReference { Instance = instance };
+
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.Remember(_contextWithZeroEntriesForBindingConfiguration, reference);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void Remember_ContextAndScopeAndReference()
+        {
+            var instance = new object();
+            var reference = new InstanceReference { Instance = instance };
+
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.Remember(_contextWithZeroEntriesForBindingConfiguration, _scopeWithZeroEntriesForBindingConfiguration, reference);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = TryGetOperationsPerInvoke)]
+        public void Release_InstanceNotFound_SingleThreaded()
+        {
+            var instance = new object();
+
+            for (var i = 0; i < TryGetOperationsPerInvoke; i++)
+            {
+                _cache.Release(instance);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = PerThreadLoopCount * ThreadCount)]
+        public void Release_InstanceNotFound_MultiThreaded()
+        {
+            var instance = new object();
+
+            var tasks = Enumerable.Range(1, ThreadCount)
+                                  .Select(_ => Task.Factory.StartNew(() =>
+                                      {
+                                          for (var i = 0; i < PerThreadLoopCount; i++)
+                                          {
+                                              _cache.Release(instance);
+                                          }
+                                      },
+                                      TaskCreationOptions.LongRunning));
+
+            Task.WaitAll(tasks.ToArray());
+        }
+
+        [Benchmark]
+        public void RememberAndRelease_ContextAndReference_Singlethreaded()
+        {
+            _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, _instanceReferenceForScopeWithZeroEntries);
+            _cache.Release(_instanceForScopeWithZeroEntries);
+        }
+
+        [Benchmark(OperationsPerInvoke = PerThreadLoopCount * ThreadCount)]
+        public void RememberAndRelease_ContextAndReference_Multithreaded()
+        {
+            var tasks = Enumerable.Range(1, ThreadCount)
+                                  .Select(_ => Task.Factory.StartNew(() =>
+                                      {
+                                          var instance = new object();
+                                          var reference = new InstanceReference { Instance = instance };
+
+                                          for (var i = 0; i < PerThreadLoopCount; i++)
+                                          {
+                                              _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, reference);
+                                              _cache.Release(instance);
+                                          }
+                                      },
+                                      TaskCreationOptions.LongRunning));
+
+            Task.WaitAll(tasks.ToArray());
+        }
+
+        [Benchmark]
+        public void RememberAndRelease_ContextAndScopeAndReference_Singlethreaded()
+        {
+            _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, _scopeWithOneEntryForBindingConfiguration, _instanceReferenceForScopeWithZeroEntries);
+            _cache.Release(_instanceForScopeWithZeroEntries);
+        }
+
+        [Benchmark(OperationsPerInvoke = PerThreadLoopCount * ThreadCount)]
+        public void RememberAndRelease_ContextAndScopeAndReference_Multithreaded()
+        {
+            var tasks = Enumerable.Range(1, ThreadCount)
+                                  .Select(_ => Task.Factory.StartNew(() =>
+                                      {
+                                          var instance = new object();
+                                          var reference = new InstanceReference { Instance = instance };
+
+                                          for (var i = 0; i < PerThreadLoopCount; i++)
+                                          {
+                                              _cache.Remember(_contextWithMoreThanOneEntryForBindingConfiguration, _scopeWithOneEntryForBindingConfiguration, reference);
+                                              _cache.Release(instance);
+                                          }
+                                      },
+                                      TaskCreationOptions.LongRunning));
+
+            Task.WaitAll(tasks.ToArray());
+        }
+
+        private static Context CreateContext(IKernelConfiguration kernelConfiguration, IReadOnlyKernel readonlyKernel, Type serviceType, object scope, INinjectSettings ninjectSettings)
+        {
+            var request = new Request(typeof(CacheBenchmark),
+                                      null,
+                                      Enumerable.Empty<IParameter>(),
+                                      null,
+                                      false,
+                                      true);
+
+            var binding = new Binding(serviceType);
+            
+            if (scope != null)
+            {
+                binding.ScopeCallback = ctx => scope;
+            }
+
+            return new Context(readonlyKernel,
+                               ninjectSettings,
+                               request,
+                               binding,
+                               kernelConfiguration.Components.Get<ICache>(),
+                               kernelConfiguration.Components.Get<IPlanner>(),
+                               kernelConfiguration.Components.Get<IPipeline>(),
+                               kernelConfiguration.Components.Get<IExceptionFormatter>());
+        }
+
+
+        public class NoOpCachePruner : ICachePruner
+        {
+            public void Dispose()
+            {
+            }
+
+            public void Start(IPruneable cache)
+            {
+            }
+
+            public void Stop()
+            {
+            }
+        }
+    }
+}

--- a/src/Ninject.Test/Unit/Activation/Caching/CacheTests.cs
+++ b/src/Ninject.Test/Unit/Activation/Caching/CacheTests.cs
@@ -4,6 +4,7 @@ using Ninject.Activation.Caching;
 using Ninject.Infrastructure.Disposal;
 using Ninject.Planning.Bindings;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Ninject.Tests.Unit.Activation.Caching
@@ -12,18 +13,24 @@ namespace Ninject.Tests.Unit.Activation.Caching
     {
         private Mock<IPipeline> _pipelineMock;
         private Mock<ICachePruner> _cachePrunerMock;
-        private Mock<IContext> _contextMock;
-        private Mock<IBinding> _bindingMock;
-        private Mock<IBindingConfiguration> _bindingConfigurationMock;
+        private Mock<IContext> _contextMock1;
+        private Mock<IContext> _contextMock2;
+        private Mock<IBinding> _bindingMock1;
+        private Mock<IBinding> _bindingMock2;
+        private Mock<IBindingConfiguration> _bindingConfigurationMock1;
+        private Mock<IBindingConfiguration> _bindingConfigurationMock2;
         private MockSequence _mockSequence;
 
         public CacheTest()
         {
             _pipelineMock = new Mock<IPipeline>(MockBehavior.Strict);
             _cachePrunerMock = new Mock<ICachePruner>(MockBehavior.Strict);
-            _contextMock = new Mock<IContext>(MockBehavior.Strict);
-            _bindingMock = new Mock<IBinding>(MockBehavior.Strict);
-            _bindingConfigurationMock = new Mock<IBindingConfiguration>(MockBehavior.Strict);
+            _contextMock1 = new Mock<IContext>(MockBehavior.Strict);
+            _contextMock2 = new Mock<IContext>(MockBehavior.Strict);
+            _bindingMock1 = new Mock<IBinding>(MockBehavior.Strict);
+            _bindingMock2 = new Mock<IBinding>(MockBehavior.Strict);
+            _bindingConfigurationMock1 = new Mock<IBindingConfiguration>(MockBehavior.Strict);
+            _bindingConfigurationMock2 = new Mock<IBindingConfiguration>(MockBehavior.Strict);
 
             _mockSequence = new MockSequence();
         }
@@ -93,7 +100,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
         [Fact]
         public void Remember_ContextAndScopeAndReference_ShouldThrowArgumentNullExceptionWhenScopeIsNull()
         {
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             const object scope = null;
             var instanceReference = new InstanceReference { Instance = new object() };
             var cache = CreateCache();
@@ -107,12 +114,12 @@ namespace Ninject.Tests.Unit.Activation.Caching
         [Fact]
         public void Remember_ContextAndScopeAndReference_ShouldKeepWeakReferenceToScope()
         {
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            var scope = Remember(cache, _contextMock, _bindingConfigurationMock.Object, instanceReference);
+            var scope = Remember(cache, _contextMock1, _bindingConfigurationMock1.Object, instanceReference);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -123,39 +130,39 @@ namespace Ninject.Tests.Unit.Activation.Caching
         [Fact]
         public void Remember_ContextAndScopeAndReference_ShouldKeepWeakReferenceToDisposableScope()
         {
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
-            _pipelineMock.InSequence(_mockSequence).Setup(p => p.Deactivate(_contextMock.Object, instanceReference));
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _pipelineMock.InSequence(_mockSequence).Setup(p => p.Deactivate(_contextMock1.Object, instanceReference));
 
-            var disposabledScope = RememberDisposableScope(cache, _contextMock, _bindingConfigurationMock.Object, instanceReference);
+            var disposabledScope = RememberDisposableScope(cache, _contextMock1, _bindingConfigurationMock1.Object, instanceReference);
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
             Assert.False(disposabledScope.IsAlive);
 
-            _pipelineMock.Verify(p => p.Deactivate(_contextMock.Object, instanceReference), Times.Never());
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock1.Object, instanceReference), Times.Never());
         }
 
         [Fact]
         public void Remember_ContextAndScopeAndReference_ShouldSubscripeToDisposedEventWhenScopeImplementsINotifyWhenDisposedAndClearCacheForTheScopeUponDispose()
         {
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var scope = new DisposableScope();
             var cache = CreateCache();
             var instance = new object();
             var instanceReference1 = new InstanceReference { Instance = instance };
             var instanceReference2 = new InstanceReference { Instance = instance };
 
-            Remember(cache, _contextMock, new object(), _bindingConfigurationMock.Object, instanceReference1);
-            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, instanceReference2);
+            Remember(cache, _contextMock1, new object(), _bindingConfigurationMock1.Object, instanceReference1);
+            Remember(cache, _contextMock1, scope, _bindingConfigurationMock1.Object, instanceReference2);
 
-            _pipelineMock.InSequence(_mockSequence).Setup(p => p.Deactivate(_contextMock.Object, instanceReference2));
+            _pipelineMock.InSequence(_mockSequence).Setup(p => p.Deactivate(_contextMock1.Object, instanceReference2));
 
             Assert.Equal(2, cache.Count);
 
@@ -164,7 +171,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
             Assert.Equal(1, cache.Count);
             Assert.Null(cache.TryGet(context, scope));
 
-            _pipelineMock.Verify(p => p.Deactivate(_contextMock.Object, instanceReference2));
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock1.Object, instanceReference2));
         }
 
         [Fact]
@@ -195,7 +202,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
         [Fact]
         public void TryGet_ContextAndScope_ShouldThrowArgumentNullExceptionWhenScopeIsNull()
         {
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             const object scope = null;
             var cache = CreateCache();
 
@@ -208,7 +215,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
         [Fact]
         public void TryGet_ContextAndScope_ShouldReturnNullWhenNothingHasBeenRememberedForSpecifiedScope()
         {
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var scope = new object();
             var cache = CreateCache();
 
@@ -221,76 +228,76 @@ namespace Ninject.Tests.Unit.Activation.Caching
         public void TryGet_ContextAndScope_ShouldReturnNullWhenNothingHasBeenRememberedForBindingConfiguration()
         {
             var otherBindingConfiguration = new Mock<IBindingConfiguration>(MockBehavior.Strict).Object;
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var scope = new object();
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            Remember(cache, _contextMock, scope, otherBindingConfiguration, instanceReference);
+            Remember(cache, _contextMock1, scope, otherBindingConfiguration, instanceReference);
 
-            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
 
             var actual = cache.TryGet(context, scope);
 
             Assert.Null(actual);
 
-            _contextMock.Verify(p => p.Binding, Times.Once());
-            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock1.Verify(p => p.Binding, Times.Once());
+            _bindingMock1.Verify(p => p.BindingConfiguration, Times.Once());
         }
 
         [Fact]
         public void TryGet_ContextAndScope_ShouldReturnRememberedInstanceForBindingConfigurationWhenContextDoesNotHaveInferredGenericArguments()
         {
             var otherBindingConfiguration = new Mock<IBindingConfiguration>(MockBehavior.Strict).Object;
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var scope = new object();
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+            Remember(cache, _contextMock1, scope, _bindingConfigurationMock1.Object, instanceReference);
 
-            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
-            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(false);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock1.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(false);
 
             var actual = cache.TryGet(context, scope);
 
             Assert.NotNull(actual);
             Assert.Same(instance, actual);
 
-            _contextMock.Verify(p => p.Binding, Times.Once());
-            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock1.Verify(p => p.Binding, Times.Once());
+            _bindingMock1.Verify(p => p.BindingConfiguration, Times.Once());
         }
 
         [Fact]
         public void TryGet_ContextAndScope_ShouldReturnFirstRememberedInstanceForBindingConfigurationWhenMoreThanOneInstanceIsRememberedAndContextDoesNotHaveInferredGenericArguments()
         {
             var otherBindingConfiguration = new Mock<IBindingConfiguration>(MockBehavior.Strict).Object;
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var scope = new object();
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            Remember(cache, _contextMock, scope, otherBindingConfiguration, new InstanceReference { Instance = new object() });
-            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, instanceReference);
-            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, new InstanceReference { Instance = new object() });
-            Remember(cache, _contextMock, scope, otherBindingConfiguration, new InstanceReference { Instance = new object() });
+            Remember(cache, _contextMock1, scope, otherBindingConfiguration, new InstanceReference { Instance = new object() });
+            Remember(cache, _contextMock1, scope, _bindingConfigurationMock1.Object, instanceReference);
+            Remember(cache, _contextMock1, scope, _bindingConfigurationMock1.Object, new InstanceReference { Instance = new object() });
+            Remember(cache, _contextMock1, scope, otherBindingConfiguration, new InstanceReference { Instance = new object() });
 
-            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
-            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(false);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock1.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(false);
 
             var actual = cache.TryGet(context, scope);
 
             Assert.NotNull(actual);
             Assert.Same(instance, actual);
 
-            _contextMock.Verify(p => p.Binding, Times.Once());
-            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock1.Verify(p => p.Binding, Times.Once());
+            _bindingMock1.Verify(p => p.BindingConfiguration, Times.Once());
         }
 
         [Fact]
@@ -298,30 +305,30 @@ namespace Ninject.Tests.Unit.Activation.Caching
         {
             var rememberedInstanceContextMock = new Mock<IContext>(MockBehavior.Strict);
             var rememberedInstanceContextGenericArguments = new Type[0];
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var contextGenericArguments = new[] { typeof(string) };
             var scope = new object();
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            Remember(cache, rememberedInstanceContextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+            Remember(cache, rememberedInstanceContextMock, scope, _bindingConfigurationMock1.Object, instanceReference);
 
-            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
-            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock1.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
             rememberedInstanceContextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(rememberedInstanceContextGenericArguments);
-            _contextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
 
             var actual = cache.TryGet(context, scope);
 
             Assert.Null(actual);
 
-            _contextMock.Verify(p => p.Binding, Times.Once());
-            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
-            _contextMock.Verify(p => p.HasInferredGenericArguments, Times.Once());
+            _contextMock1.Verify(p => p.Binding, Times.Once());
+            _bindingMock1.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock1.Verify(p => p.HasInferredGenericArguments, Times.Once());
             rememberedInstanceContextMock.Verify(p => p.GenericArguments, Times.Once());
-            _contextMock.Verify(p => p.GenericArguments, Times.Once());
+            _contextMock1.Verify(p => p.GenericArguments, Times.Once());
         }
 
         [Fact]
@@ -331,36 +338,342 @@ namespace Ninject.Tests.Unit.Activation.Caching
             var rememberedInstance1ContextGenericArguments = new[] { typeof(string), typeof(int) };
             var rememberedInstance2ContextMock = new Mock<IContext>(MockBehavior.Strict);
             var rememberedInstance2ContextGenericArguments = new[] { typeof(string), typeof(bool) };
-            var context = _contextMock.Object;
+            var context = _contextMock1.Object;
             var contextGenericArguments = new[] { typeof(string), typeof(bool) };
             var scope = new object();
             var cache = CreateCache();
             var instance = new object();
             var instanceReference = new InstanceReference { Instance = instance };
 
-            Remember(cache, rememberedInstance1ContextMock, scope, _bindingConfigurationMock.Object, new InstanceReference { Instance = new object()});
-            Remember(cache, rememberedInstance2ContextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+            Remember(cache, rememberedInstance1ContextMock, scope, _bindingConfigurationMock1.Object, new InstanceReference { Instance = new object()});
+            Remember(cache, rememberedInstance2ContextMock, scope, _bindingConfigurationMock1.Object, instanceReference);
 
-            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
-            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock1.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
             rememberedInstance1ContextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(rememberedInstance1ContextGenericArguments);
-            _contextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
-            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
+            _contextMock1.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
             rememberedInstance2ContextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(rememberedInstance2ContextGenericArguments);
-            _contextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
+            _contextMock1.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
 
             var actual = cache.TryGet(context, scope);
 
             Assert.NotNull(actual);
             Assert.Same(instance, actual);
 
-            _contextMock.Verify(p => p.Binding, Times.Once());
-            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
-            _contextMock.Verify(p => p.HasInferredGenericArguments, Times.Exactly(2));
+            _contextMock1.Verify(p => p.Binding, Times.Once());
+            _bindingMock1.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock1.Verify(p => p.HasInferredGenericArguments, Times.Exactly(2));
             rememberedInstance1ContextMock.Verify(p => p.GenericArguments, Times.Once());
             rememberedInstance2ContextMock.Verify(p => p.GenericArguments, Times.Once());
-            _contextMock.Verify(p => p.GenericArguments, Times.Exactly(2));
+            _contextMock1.Verify(p => p.GenericArguments, Times.Exactly(2));
+        }
+
+        [Fact]
+        public void Release_NullInstance_NoCacheEntriesFound()
+        {
+            var rememberedInstance1ContextMock = new Mock<IContext>(MockBehavior.Strict);
+            var rememberedInstance2ContextMock = new Mock<IContext>(MockBehavior.Strict);
+            var scope1 = new object();
+            var scope2 = new object();
+            var cache = CreateCache();
+            const object instance = null;
+
+            Remember(cache, rememberedInstance1ContextMock, scope1, _bindingConfigurationMock1.Object, new InstanceReference { Instance = new object() });
+            Remember(cache, rememberedInstance2ContextMock, scope2, _bindingConfigurationMock1.Object, new InstanceReference { Instance = new object() });
+
+            var actual = cache.Release(instance);
+
+            Assert.False(actual);
+        }
+
+        [Fact]
+        public void Release_NullInstance_CacheEntriesFound()
+        {
+            var contextMock1 = new Mock<IContext>(MockBehavior.Strict);
+            var contextMock2 = new Mock<IContext>(MockBehavior.Strict);
+            var contextMock3 = new Mock<IContext>(MockBehavior.Strict);
+            var bindingMock1 = new Mock<IBinding>(MockBehavior.Strict);
+            var bindingMock2 = new Mock<IBinding>(MockBehavior.Strict);
+            var bindingConfigurationMock1 = new Mock<IBindingConfiguration>(MockBehavior.Strict);
+            var bindingConfigurationMock2 = new Mock<IBindingConfiguration>(MockBehavior.Strict);
+
+            var scope1 = new object();
+            var scope2 = new object();
+            var cache = CreateCache();
+            const object nullInstance = null;
+            var nullInstanceReference1 = new InstanceReference { Instance = nullInstance };
+            var nullInstanceReference2 = new InstanceReference { Instance = nullInstance };
+            var nullInstanceReference3 = new InstanceReference { Instance = nullInstance };
+            var notNullInstanceReference1 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference2 = new InstanceReference { Instance = new object() };
+
+            contextMock1.Setup(p => p.Binding).Returns(bindingMock1.Object);
+            contextMock2.Setup(p => p.Binding).Returns(bindingMock1.Object);
+            contextMock3.Setup(p => p.Binding).Returns(bindingMock2.Object);
+            bindingMock1.Setup(p => p.BindingConfiguration).Returns(bindingConfigurationMock1.Object);
+            bindingMock2.Setup(p => p.BindingConfiguration).Returns(bindingConfigurationMock2.Object);
+
+            cache.Remember(contextMock1.Object, scope1, notNullInstanceReference1);
+            cache.Remember(contextMock2.Object, scope2, nullInstanceReference1);
+            cache.Remember(contextMock1.Object, scope1, nullInstanceReference2);
+            cache.Remember(contextMock3.Object, scope2, notNullInstanceReference2);
+            cache.Remember(contextMock1.Object, scope2, nullInstanceReference3);
+
+            _pipelineMock.Setup(p => p.Deactivate(contextMock1.Object, nullInstanceReference3));
+            _pipelineMock.Setup(p => p.Deactivate(contextMock2.Object, nullInstanceReference1));
+            _pipelineMock.Setup(p => p.Deactivate(contextMock1.Object, nullInstanceReference2));
+
+            var actualException = Assert.Throws<ArgumentNullException>(() => cache.Release(nullInstance));
+
+            Assert.Null(actualException.InnerException);
+            Assert.Equal("key", actualException.ParamName);
+
+            _pipelineMock.Verify(p => p.Deactivate(contextMock1.Object, nullInstanceReference3), Times.Once());
+            _pipelineMock.Verify(p => p.Deactivate(contextMock2.Object, nullInstanceReference1), Times.Once());
+            _pipelineMock.Verify(p => p.Deactivate(contextMock1.Object, nullInstanceReference2), Times.Once());
+
+            Assert.Equal(2, cache.Count);
+
+            contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+            contextMock3.Setup(p => p.HasInferredGenericArguments).Returns(false);
+
+            Assert.Same(notNullInstanceReference1.Instance, cache.TryGet(contextMock1.Object, scope1));
+            Assert.Same(notNullInstanceReference2.Instance, cache.TryGet(contextMock3.Object, scope2));
+        }
+
+        [Fact]
+        public void Release_NotNullInstance_NoCacheEntriesOrScopeFound()
+        {
+            var scope1 = new object();
+            var scope2 = new object();
+            var cache = CreateCache();
+            var notNullInstanceReference1 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference2 = new InstanceReference { Instance = new object() };
+
+            _contextMock1.Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+
+            cache.Remember(_contextMock1.Object, scope1, notNullInstanceReference1);
+            cache.Remember(_contextMock1.Object, scope2, notNullInstanceReference2);
+
+            var actual = cache.Release(new object());
+
+            Assert.False(actual);
+
+            Assert.Equal(2, cache.Count);
+
+            _contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+
+            Assert.Same(notNullInstanceReference1.Instance, cache.TryGet(_contextMock1.Object, scope1));
+            Assert.Same(notNullInstanceReference2.Instance, cache.TryGet(_contextMock1.Object, scope2));
+        }
+
+        [Fact]
+        public void Release_NotNullInstance_OnlyCacheEntriesFound()
+        {
+            var scope1 = new object();
+            var scope2 = new object();
+            var cache = CreateCache();
+            var notNullInstanceReference1 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference2 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference3 = new InstanceReference { Instance = new object() };
+
+            _contextMock1.Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock2.Setup(p => p.Binding).Returns(_bindingMock2.Object);
+            _bindingMock2.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock2.Object);
+
+            cache.Remember(_contextMock1.Object, scope1, notNullInstanceReference1);
+            cache.Remember(_contextMock1.Object, scope2, notNullInstanceReference2);
+            cache.Remember(_contextMock2.Object, scope1, notNullInstanceReference1);
+            cache.Remember(_contextMock2.Object, scope2, notNullInstanceReference3);
+
+            Assert.Equal(4, cache.Count);
+
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock1.Object, notNullInstanceReference1));
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock2.Object, notNullInstanceReference1));
+
+            var actual = cache.Release(notNullInstanceReference1.Instance);
+
+            Assert.True(actual);
+
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock1.Object, notNullInstanceReference1), Times.Once());
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock2.Object, notNullInstanceReference1), Times.Once());
+
+            Assert.Equal(2, cache.Count);
+
+            _contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+            _contextMock2.Setup(p => p.HasInferredGenericArguments).Returns(false);
+
+            Assert.Same(notNullInstanceReference2.Instance, cache.TryGet(_contextMock1.Object, scope2));
+            Assert.Same(notNullInstanceReference3.Instance, cache.TryGet(_contextMock2.Object, scope2));
+        }
+
+        [Fact]
+        public void Release_NotNullInstance_OnlyScopeFound()
+        {
+            var scope1 = new object();
+            var scope2 = new object();
+            var cache = CreateCache();
+            var notNullInstanceReference1 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference2 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference3 = new InstanceReference { Instance = new object() };
+
+            _contextMock1.Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock2.Setup(p => p.Binding).Returns(_bindingMock2.Object);
+            _bindingMock2.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock2.Object);
+
+            cache.Remember(_contextMock1.Object, scope1, notNullInstanceReference1);
+            cache.Remember(_contextMock1.Object, scope2, notNullInstanceReference2);
+
+            Assert.Equal(2, cache.Count);
+
+            var actual = cache.Release(scope2);
+
+            Assert.False(actual);
+
+            Assert.Equal(2, cache.Count);
+
+            _contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+            _contextMock2.Setup(p => p.HasInferredGenericArguments).Returns(false);
+
+            Assert.Same(notNullInstanceReference1.Instance, cache.TryGet(_contextMock1.Object, scope1));
+            Assert.Same(notNullInstanceReference2.Instance, cache.TryGet(_contextMock1.Object, scope2));
+        }
+
+        /// <summary>
+        /// scope 1
+        ///     - reference 1
+        ///     - reference 2 => scope 2
+        /// scope 2
+        ///     - reference 3
+        ///     - reference 4 => scope 4
+        /// scope 3
+        ///     - reference 5
+        /// scope 4
+        ///     - reference 6
+        ///     
+        /// Removing the instance in reference 2 should remove scope 2 and scope 4.
+        /// </summary>
+        [Fact]
+        public void Release_NotNullInstance_CacheEntriesAndScopeFound()
+        {
+            var scope1 = new object();
+            var scope2 = new object();
+            var scope3 = new object();
+            var scope4 = new object();
+            var cache = CreateCache();
+            var notNullInstanceReference1 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference2 = new InstanceReference { Instance = scope2 };
+            var notNullInstanceReference3 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference4 = new InstanceReference { Instance = scope4 };
+            var notNullInstanceReference5 = new InstanceReference { Instance = new object() };
+            var notNullInstanceReference6 = new InstanceReference { Instance = new object() };
+
+            _contextMock1.Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock2.Setup(p => p.Binding).Returns(_bindingMock2.Object);
+            _bindingMock2.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock2.Object);
+
+            cache.Remember(_contextMock1.Object, scope1, notNullInstanceReference1);
+            cache.Remember(_contextMock1.Object, scope1, notNullInstanceReference2);
+            cache.Remember(_contextMock2.Object, scope2, notNullInstanceReference3);
+            cache.Remember(_contextMock1.Object, scope2, notNullInstanceReference4);
+            cache.Remember(_contextMock2.Object, scope3, notNullInstanceReference5);
+            cache.Remember(_contextMock2.Object, scope4, notNullInstanceReference6);
+
+            Assert.Equal(6, cache.Count);
+
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock1.Object, notNullInstanceReference2));
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock2.Object, notNullInstanceReference3));
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock1.Object, notNullInstanceReference4));
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock2.Object, notNullInstanceReference6));
+
+            var actual = cache.Release(scope2);
+
+            Assert.True(actual);
+
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock1.Object, notNullInstanceReference2), Times.Once());
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock2.Object, notNullInstanceReference3), Times.Once());
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock1.Object, notNullInstanceReference4), Times.Once());
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock2.Object, notNullInstanceReference6), Times.Once());
+
+            Assert.Equal(2, cache.Count);
+
+            _contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+            _contextMock2.Setup(p => p.HasInferredGenericArguments).Returns(false);
+
+            Assert.Same(notNullInstanceReference1.Instance, cache.TryGet(_contextMock1.Object, scope1));
+            Assert.Same(notNullInstanceReference5.Instance, cache.TryGet(_contextMock2.Object, scope3));
+        }
+
+        [Fact]
+        public void Concurrency()
+        {
+            var cache = CreateCache();
+            var scope = new object();
+            var instance = new object();
+
+            _contextMock1.Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
+            _contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+
+            var tryGetTask = new Task(() =>
+            {
+                for (var i = 0; i < 5000; i++)
+                {
+                    cache.TryGet(_contextMock1.Object, scope);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            var rememberTask = new Task(() =>
+            {
+                var reference = new InstanceReference { Instance = instance };
+
+                for (var i = 0; i < 5000; i++)
+                {
+                    cache.Remember(_contextMock1.Object, scope, reference);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            var releaseTask = new Task(() =>
+            {
+                for (var i = 0; i < 5000; i++)
+                {
+                    cache.Release(instance);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            var clearScopeTask = new Task(() =>
+            {
+                for (var i = 0; i < 5000; i++)
+                {
+                    cache.Clear(scope);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            var clearTask = new Task(() =>
+            {
+                for (var i = 0; i < 5000; i++)
+                {
+                    cache.Clear();
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            clearTask.Start();
+            clearScopeTask.Start();
+            rememberTask.Start();
+            releaseTask.Start();
+            tryGetTask.Start();
+
+            clearTask.ConfigureAwait(false).GetAwaiter().GetResult();
+            clearScopeTask.ConfigureAwait(false).GetAwaiter().GetResult();
+            rememberTask.ConfigureAwait(false).GetAwaiter().GetResult();
+            releaseTask.ConfigureAwait(false).GetAwaiter().GetResult();
+            tryGetTask.ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         private Cache CreateCache()
@@ -372,26 +685,26 @@ namespace Ninject.Tests.Unit.Activation.Caching
 
         private void Remember(Cache cache, Mock<IContext> contextMock, object scope, IBindingConfiguration bindingConfiguration, InstanceReference instanceReference)
         {
-            contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(bindingConfiguration);
+            contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(bindingConfiguration);
 
             cache.Remember(contextMock.Object, scope, instanceReference);
 
             contextMock.Reset();
-            _bindingMock.Reset();
+            _bindingMock1.Reset();
         }
 
         private WeakReference Remember(Cache cache, Mock<IContext> contextMock, IBindingConfiguration bindingConfiguration, InstanceReference instanceReference)
         {
             var scope = new object();
 
-            contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
-            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(bindingConfiguration);
+            contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock1.Object);
+            _bindingMock1.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(bindingConfiguration);
 
             cache.Remember(contextMock.Object, scope, instanceReference);
 
             contextMock.Reset();
-            _bindingMock.Reset();
+            _bindingMock1.Reset();
 
             return new WeakReference(scope);
         }

--- a/src/Ninject.Test/Unit/Activation/Caching/CacheTests.cs
+++ b/src/Ninject.Test/Unit/Activation/Caching/CacheTests.cs
@@ -1,6 +1,8 @@
 ﻿using Moq;
 using Ninject.Activation;
 using Ninject.Activation.Caching;
+using Ninject.Infrastructure.Disposal;
+using Ninject.Planning.Bindings;
 using System;
 using Xunit;
 
@@ -10,11 +12,20 @@ namespace Ninject.Tests.Unit.Activation.Caching
     {
         private Mock<IPipeline> _pipelineMock;
         private Mock<ICachePruner> _cachePrunerMock;
+        private Mock<IContext> _contextMock;
+        private Mock<IBinding> _bindingMock;
+        private Mock<IBindingConfiguration> _bindingConfigurationMock;
+        private MockSequence _mockSequence;
 
         public CacheTest()
         {
             _pipelineMock = new Mock<IPipeline>(MockBehavior.Strict);
             _cachePrunerMock = new Mock<ICachePruner>(MockBehavior.Strict);
+            _contextMock = new Mock<IContext>(MockBehavior.Strict);
+            _bindingMock = new Mock<IBinding>(MockBehavior.Strict);
+            _bindingConfigurationMock = new Mock<IBindingConfiguration>(MockBehavior.Strict);
+
+            _mockSequence = new MockSequence();
         }
 
         [Fact]
@@ -53,7 +64,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
         }
 
         [Fact]
-        public void Remember_ShouldThrowArgumentNullExceptionWhenContextIsNull()
+        public void Remember_ContextAndReference_ShouldThrowArgumentNullExceptionWhenContextIsNull()
         {
             const IContext context = null;
             var instanceReference = new InstanceReference { Instance = new object() };
@@ -66,7 +77,98 @@ namespace Ninject.Tests.Unit.Activation.Caching
         }
 
         [Fact]
-        public void TryGet_ShouldThrowArgumentNullExceptionWhenContextIsNull()
+        public void Remember_ContextAndScopeAndReference_ShouldThrowArgumentNullExceptionWhenContextIsNull()
+        {
+            const IContext context = null;
+            var scope = new object();
+            var instanceReference = new InstanceReference { Instance = new object() };
+            var cache = CreateCache();
+
+            var actual = Assert.Throws<ArgumentNullException>(() => cache.Remember(context, scope, instanceReference));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(context), actual.ParamName);
+        }
+
+        [Fact]
+        public void Remember_ContextAndScopeAndReference_ShouldThrowArgumentNullExceptionWhenScopeIsNull()
+        {
+            var context = _contextMock.Object;
+            const object scope = null;
+            var instanceReference = new InstanceReference { Instance = new object() };
+            var cache = CreateCache();
+
+            var actual = Assert.Throws<ArgumentNullException>(() => cache.Remember(context, scope, instanceReference));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(scope), actual.ParamName);
+        }
+
+        [Fact]
+        public void Remember_ContextAndScopeAndReference_ShouldKeepWeakReferenceToScope()
+        {
+            var context = _contextMock.Object;
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            var scope = Remember(cache, _contextMock, _bindingConfigurationMock.Object, instanceReference);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(scope.IsAlive);
+        }
+
+        [Fact]
+        public void Remember_ContextAndScopeAndReference_ShouldKeepWeakReferenceToDisposableScope()
+        {
+            var context = _contextMock.Object;
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+            _pipelineMock.InSequence(_mockSequence).Setup(p => p.Deactivate(_contextMock.Object, instanceReference));
+
+            var disposabledScope = RememberDisposableScope(cache, _contextMock, _bindingConfigurationMock.Object, instanceReference);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            Assert.False(disposabledScope.IsAlive);
+
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock.Object, instanceReference), Times.Never());
+        }
+
+        [Fact]
+        public void Remember_ContextAndScopeAndReference_ShouldSubscripeToDisposedEventWhenScopeImplementsINotifyWhenDisposedAndClearCacheForTheScopeUponDispose()
+        {
+            var context = _contextMock.Object;
+            var scope = new DisposableScope();
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference1 = new InstanceReference { Instance = instance };
+            var instanceReference2 = new InstanceReference { Instance = instance };
+
+            Remember(cache, _contextMock, new object(), _bindingConfigurationMock.Object, instanceReference1);
+            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, instanceReference2);
+
+            _pipelineMock.InSequence(_mockSequence).Setup(p => p.Deactivate(_contextMock.Object, instanceReference2));
+
+            Assert.Equal(2, cache.Count);
+
+            scope.Dispose();
+
+            Assert.Equal(1, cache.Count);
+            Assert.Null(cache.TryGet(context, scope));
+
+            _pipelineMock.Verify(p => p.Deactivate(_contextMock.Object, instanceReference2));
+        }
+
+        [Fact]
+        public void TryGet_Context_ShouldThrowArgumentNullExceptionWhenContextIsNull()
         {
             const IContext context = null;
             var cache = CreateCache();
@@ -77,11 +179,234 @@ namespace Ninject.Tests.Unit.Activation.Caching
             Assert.Equal(nameof(context), actual.ParamName);
         }
 
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldThrowArgumentNullExceptionWhenContextIsNull()
+        {
+            const IContext context = null;
+            var scope = new object();
+            var cache = CreateCache();
+
+            var actual = Assert.Throws<ArgumentNullException>(() => cache.TryGet(context, scope));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(context), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldThrowArgumentNullExceptionWhenScopeIsNull()
+        {
+            var context = _contextMock.Object;
+            const object scope = null;
+            var cache = CreateCache();
+
+            var actual = Assert.Throws<ArgumentNullException>(() => cache.TryGet(context, scope));
+
+            Assert.Null(actual.InnerException);
+            Assert.Equal(nameof(scope), actual.ParamName);
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldReturnNullWhenNothingHasBeenRememberedForSpecifiedScope()
+        {
+            var context = _contextMock.Object;
+            var scope = new object();
+            var cache = CreateCache();
+
+            var actual = cache.TryGet(context, scope);
+
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldReturnNullWhenNothingHasBeenRememberedForBindingConfiguration()
+        {
+            var otherBindingConfiguration = new Mock<IBindingConfiguration>(MockBehavior.Strict).Object;
+            var context = _contextMock.Object;
+            var scope = new object();
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            Remember(cache, _contextMock, scope, otherBindingConfiguration, instanceReference);
+
+            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+
+            var actual = cache.TryGet(context, scope);
+
+            Assert.Null(actual);
+
+            _contextMock.Verify(p => p.Binding, Times.Once());
+            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldReturnRememberedInstanceForBindingConfigurationWhenContextDoesNotHaveInferredGenericArguments()
+        {
+            var otherBindingConfiguration = new Mock<IBindingConfiguration>(MockBehavior.Strict).Object;
+            var context = _contextMock.Object;
+            var scope = new object();
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+
+            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(false);
+
+            var actual = cache.TryGet(context, scope);
+
+            Assert.NotNull(actual);
+            Assert.Same(instance, actual);
+
+            _contextMock.Verify(p => p.Binding, Times.Once());
+            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldReturnFirstRememberedInstanceForBindingConfigurationWhenMoreThanOneInstanceIsRememberedAndContextDoesNotHaveInferredGenericArguments()
+        {
+            var otherBindingConfiguration = new Mock<IBindingConfiguration>(MockBehavior.Strict).Object;
+            var context = _contextMock.Object;
+            var scope = new object();
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            Remember(cache, _contextMock, scope, otherBindingConfiguration, new InstanceReference { Instance = new object() });
+            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+            Remember(cache, _contextMock, scope, _bindingConfigurationMock.Object, new InstanceReference { Instance = new object() });
+            Remember(cache, _contextMock, scope, otherBindingConfiguration, new InstanceReference { Instance = new object() });
+
+            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(false);
+
+            var actual = cache.TryGet(context, scope);
+
+            Assert.NotNull(actual);
+            Assert.Same(instance, actual);
+
+            _contextMock.Verify(p => p.Binding, Times.Once());
+            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldReturnNullWhenContextHasInferredGenericArgumentsAndContextOfOnlyRememberedInstanceForBindingConfigurationHasNoGenericArguments()
+        {
+            var rememberedInstanceContextMock = new Mock<IContext>(MockBehavior.Strict);
+            var rememberedInstanceContextGenericArguments = new Type[0];
+            var context = _contextMock.Object;
+            var contextGenericArguments = new[] { typeof(string) };
+            var scope = new object();
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            Remember(cache, rememberedInstanceContextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+
+            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
+            rememberedInstanceContextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(rememberedInstanceContextGenericArguments);
+            _contextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
+
+            var actual = cache.TryGet(context, scope);
+
+            Assert.Null(actual);
+
+            _contextMock.Verify(p => p.Binding, Times.Once());
+            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock.Verify(p => p.HasInferredGenericArguments, Times.Once());
+            rememberedInstanceContextMock.Verify(p => p.GenericArguments, Times.Once());
+            _contextMock.Verify(p => p.GenericArguments, Times.Once());
+        }
+
+        [Fact]
+        public void TryGet_ContextAndScope_ShouldReturnFirstRememberInstanceWithMatchingGenericArgumentsWhenContextHasInferredGenericArguments()
+        {
+            var rememberedInstance1ContextMock = new Mock<IContext>(MockBehavior.Strict);
+            var rememberedInstance1ContextGenericArguments = new[] { typeof(string), typeof(int) };
+            var rememberedInstance2ContextMock = new Mock<IContext>(MockBehavior.Strict);
+            var rememberedInstance2ContextGenericArguments = new[] { typeof(string), typeof(bool) };
+            var context = _contextMock.Object;
+            var contextGenericArguments = new[] { typeof(string), typeof(bool) };
+            var scope = new object();
+            var cache = CreateCache();
+            var instance = new object();
+            var instanceReference = new InstanceReference { Instance = instance };
+
+            Remember(cache, rememberedInstance1ContextMock, scope, _bindingConfigurationMock.Object, new InstanceReference { Instance = new object()});
+            Remember(cache, rememberedInstance2ContextMock, scope, _bindingConfigurationMock.Object, instanceReference);
+
+            _contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock.Object);
+            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
+            rememberedInstance1ContextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(rememberedInstance1ContextGenericArguments);
+            _contextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
+            _contextMock.InSequence(_mockSequence).SetupGet(p => p.HasInferredGenericArguments).Returns(true);
+            rememberedInstance2ContextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(rememberedInstance2ContextGenericArguments);
+            _contextMock.InSequence(_mockSequence).Setup(p => p.GenericArguments).Returns(contextGenericArguments);
+
+            var actual = cache.TryGet(context, scope);
+
+            Assert.NotNull(actual);
+            Assert.Same(instance, actual);
+
+            _contextMock.Verify(p => p.Binding, Times.Once());
+            _bindingMock.Verify(p => p.BindingConfiguration, Times.Once());
+            _contextMock.Verify(p => p.HasInferredGenericArguments, Times.Exactly(2));
+            rememberedInstance1ContextMock.Verify(p => p.GenericArguments, Times.Once());
+            rememberedInstance2ContextMock.Verify(p => p.GenericArguments, Times.Once());
+            _contextMock.Verify(p => p.GenericArguments, Times.Exactly(2));
+        }
+
         private Cache CreateCache()
         {
             _cachePrunerMock.Setup(p => p.Start(It.IsNotNull<IPruneable>()));
 
             return new Cache(_pipelineMock.Object, _cachePrunerMock.Object);
+        }
+
+        private void Remember(Cache cache, Mock<IContext> contextMock, object scope, IBindingConfiguration bindingConfiguration, InstanceReference instanceReference)
+        {
+            contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(bindingConfiguration);
+
+            cache.Remember(contextMock.Object, scope, instanceReference);
+
+            contextMock.Reset();
+            _bindingMock.Reset();
+        }
+
+        private WeakReference Remember(Cache cache, Mock<IContext> contextMock, IBindingConfiguration bindingConfiguration, InstanceReference instanceReference)
+        {
+            var scope = new object();
+
+            contextMock.InSequence(_mockSequence).Setup(p => p.Binding).Returns(_bindingMock.Object);
+            _bindingMock.InSequence(_mockSequence).Setup(p => p.BindingConfiguration).Returns(bindingConfiguration);
+
+            cache.Remember(contextMock.Object, scope, instanceReference);
+
+            contextMock.Reset();
+            _bindingMock.Reset();
+
+            return new WeakReference(scope);
+        }
+
+        private WeakReference RememberDisposableScope(Cache cache, Mock<IContext> contextMock, IBindingConfiguration bindingConfiguration, InstanceReference instanceReference)
+        {
+            var disposableScope = new DisposableScope();
+
+            cache.Remember(contextMock.Object, disposableScope, instanceReference);
+
+            return new WeakReference(disposableScope);
+        }
+
+        public class DisposableScope : DisposableObject
+        {
         }
     }
 }

--- a/src/Ninject.Test/Unit/Activation/Caching/CacheTests.cs
+++ b/src/Ninject.Test/Unit/Activation/Caching/CacheTests.cs
@@ -613,6 +613,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
         [Fact]
         public void Concurrency()
         {
+            const int iterations = 5_000;
             var cache = CreateCache();
             var scope = new object();
             var instance = new object();
@@ -620,10 +621,11 @@ namespace Ninject.Tests.Unit.Activation.Caching
             _contextMock1.Setup(p => p.Binding).Returns(_bindingMock1.Object);
             _bindingMock1.Setup(p => p.BindingConfiguration).Returns(_bindingConfigurationMock1.Object);
             _contextMock1.Setup(p => p.HasInferredGenericArguments).Returns(false);
+            _pipelineMock.Setup(p => p.Deactivate(_contextMock1.Object, It.Is<InstanceReference>(i => ReferenceEquals(i.Instance, instance))));
 
             var tryGetTask = new Task(() =>
             {
-                for (var i = 0; i < 5000; i++)
+                for (var i = 0; i < iterations; i++)
                 {
                     cache.TryGet(_contextMock1.Object, scope);
                 }
@@ -633,7 +635,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
             {
                 var reference = new InstanceReference { Instance = instance };
 
-                for (var i = 0; i < 5000; i++)
+                for (var i = 0; i < iterations; i++)
                 {
                     cache.Remember(_contextMock1.Object, scope, reference);
                 }
@@ -641,7 +643,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
 
             var releaseTask = new Task(() =>
             {
-                for (var i = 0; i < 5000; i++)
+                for (var i = 0; i < iterations; i++)
                 {
                     cache.Release(instance);
                 }
@@ -649,7 +651,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
 
             var clearScopeTask = new Task(() =>
             {
-                for (var i = 0; i < 5000; i++)
+                for (var i = 0; i < iterations; i++)
                 {
                     cache.Clear(scope);
                 }
@@ -657,7 +659,7 @@ namespace Ninject.Tests.Unit.Activation.Caching
 
             var clearTask = new Task(() =>
             {
-                for (var i = 0; i < 5000; i++)
+                for (var i = 0; i < iterations; i++)
                 {
                     cache.Clear();
                 }

--- a/src/Ninject/Activation/Caching/Cache.cs
+++ b/src/Ninject/Activation/Caching/Cache.cs
@@ -312,7 +312,11 @@ namespace Ninject.Activation.Caching
                 // * if there were a corresponding scope, then removing all instances from the
                 //   would allow the scope to be finalized. This means the scope itself would
                 //   be removed from the cache upon the next pruning run.
+                //
+                // Note that this will throw an ArgumentNullException if instance is null, but
+                // Ninject itself will never add a null instance to the cache.
                 this.Clear(instance);
+
                 return true;
             }
 
@@ -354,6 +358,9 @@ namespace Ninject.Activation.Caching
                             // * if there were a corresponding scope, then removing all instances from the
                             //   would allow the scope to be finalized. This means the scope itself would
                             //   be removed from the cache upon the next pruning run.
+                            //
+                            // Note that this will throw an ArgumentNullException if instance is null, but
+                            // Ninject itself will never add a null instance to the cache.
                             this.Clear(cacheEntry.Reference.Instance);
                         }
                     }

--- a/src/Ninject/Activation/Caching/ICache.cs
+++ b/src/Ninject/Activation/Caching/ICache.cs
@@ -21,6 +21,8 @@
 
 namespace Ninject.Activation.Caching
 {
+    using System;
+
     using Ninject.Components;
 
     /// <summary>
@@ -38,7 +40,18 @@ namespace Ninject.Activation.Caching
         /// </summary>
         /// <param name="context">The context to store.</param>
         /// <param name="reference">The instance reference.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
         void Remember(IContext context, InstanceReference reference);
+
+        /// <summary>
+        /// Stores the specified context in the cache.
+        /// </summary>
+        /// <param name="context">The context to store.</param>
+        /// <param name="scope">The scope of the context.</param>
+        /// <param name="reference">The instance reference.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="scope"/> is <see langword="null"/>.</exception>
+        void Remember(IContext context, object scope, InstanceReference reference);
 
         /// <summary>
         /// Tries to retrieve an instance to re-use in the specified context.
@@ -47,7 +60,20 @@ namespace Ninject.Activation.Caching
         /// <returns>
         /// The instance for re-use, or <see langword="null"/> if none has been stored.
         /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
         object TryGet(IContext context);
+
+        /// <summary>
+        /// Tries to retrieve an instance to re-use in the specified context and scope.
+        /// </summary>
+        /// <param name="context">The context that is being activated.</param>
+        /// <param name="scope">The scope in which the instance is being activated.</param>
+        /// <returns>
+        /// The instance for re-use, or <see langword="null"/> if none has been stored.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="context"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="scope"/> is <see langword="null"/>.</exception>
+        object TryGet(IContext context, object scope);
 
         /// <summary>
         /// Deactivates and releases the specified instance from the cache.

--- a/src/Ninject/Activation/Context.cs
+++ b/src/Ninject/Activation/Context.cs
@@ -153,7 +153,9 @@ namespace Ninject.Activation
         /// <summary>
         /// Gets the scope for the context that "owns" the instance activated therein.
         /// </summary>
-        /// <returns>The object that acts as the scope.</returns>
+        /// <returns>
+        /// The object that acts as the scope.
+        /// </returns>
         public object GetScope()
         {
             return this.cachedScope ?? this.Request.GetScope() ?? this.Binding.GetScope(this);
@@ -162,7 +164,9 @@ namespace Ninject.Activation
         /// <summary>
         /// Gets the provider that should be used to create the instance for this context.
         /// </summary>
-        /// <returns>The provider that should be used.</returns>
+        /// <returns>
+        /// The provider that should be used.
+        /// </returns>
         public IProvider GetProvider()
         {
             return this.Binding.GetProvider(this);
@@ -171,7 +175,9 @@ namespace Ninject.Activation
         /// <summary>
         /// Resolves the instance associated with this hook.
         /// </summary>
-        /// <returns>The resolved instance.</returns>
+        /// <returns>
+        /// The resolved instance.
+        /// </returns>
         public object Resolve()
         {
             if (this.Request.ActiveBindings.Contains(this.Binding) &&
@@ -219,11 +225,13 @@ namespace Ninject.Activation
 
         private object ResolveInternal(object scope)
         {
-            var cachedInstance = this.Cache.TryGet(this);
-
-            if (cachedInstance != null)
+            if (scope != null)
             {
-                return cachedInstance;
+                var cachedInstance = this.Cache.TryGet(this, scope);
+                if (cachedInstance != null)
+                {
+                    return cachedInstance;
+                }
             }
 
             this.Request.ActiveBindings.Push(this.Binding);
@@ -249,7 +257,7 @@ namespace Ninject.Activation
 
             if (scope != null)
             {
-                this.Cache.Remember(this, reference);
+                this.Cache.Remember(this, scope, reference);
             }
 
             if (this.Plan == null)


### PR DESCRIPTION
> Marked **WIP** as I still need to update tests for **Context**, and want to increase test coverage for **Cache**.

**Cache:**
* Add overloads of **Remember** and **TryGet** that take scope.
* Fixed thread safety.
* Improve overal performance and reduce allocations.

**Context:**
* Use new `Remember(IContext context, object scope, InstanceReference reference)` and `TryGet(IContext context, object scope)` overloads on **Cache**.
* Only try to get instance from cache when there's a scope

**Before:**

|                                         Method |       Mean |     Error |     StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|----------------------------------------------- |-----------:|----------:|-----------:|------------:|------------:|------------:|--------------------:|
|                         TryGet_NoCacheForScope |   127.5 ns |  1.966 ns |   1.839 ns |           - |           - |           - |                   - |
|         TryGet_OneEntryForBindingConfiguration |   344.6 ns |  6.823 ns |   8.380 ns |      0.0093 |           - |           - |                40 B |
|      TryGet_ZeroEntriesForBindingConfiguration |   320.8 ns |  6.211 ns |   6.646 ns |      0.0093 |           - |           - |                40 B |
| TryGet_MoreThanOneEntryForBindingConfiguration |   345.3 ns |  6.699 ns |   6.879 ns |      0.0093 |           - |           - |                40 B |
|                       Remember_NoCacheForScope | 2,359.4 ns | 46.578 ns |  69.716 ns |      0.3438 |           - |           - |              1456 B |
|                                       Remember | 1,541.7 ns | 30.168 ns |  38.152 ns |      0.0371 |      0.0098 |           - |               240 B |
|        Release_InstanceNotFound_SingleThreaded | 2,684.2 ns | 55.521 ns | 113.415 ns |      0.2695 |           - |           - |              1136 B |
|         Release_InstanceNotFound_MultiThreaded | 4,088.8 ns | 27.446 ns |  24.330 ns |      0.2700 |           - |           - |                   - |
|              RememberAndRelease_Singlethreaded | 3,653.0 ns | 27.788 ns |  24.633 ns |      0.3624 |           - |           - |              1528 B |
|               RememberAndRelease_Multithreaded |         NA |        NA |         NA |           - |           - |           - |                   - |

Note:
The last benchmark fails due to a concurrency issue which is fixed by this PR.

**After:**


|                                         Method |        Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|----------------------------------------------- |------------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|                         TryGet_NoCacheForScope |    60.90 ns | 0.1086 ns | 0.0907 ns |           - |           - |           - |                   - |
|         TryGet_OneEntryForBindingConfiguration |   208.53 ns | 0.2269 ns | 0.2011 ns |           - |           - |           - |                   - |
|      TryGet_ZeroEntriesForBindingConfiguration |   200.74 ns | 0.1229 ns | 0.1026 ns |           - |           - |           - |                   - |
| TryGet_MoreThanOneEntryForBindingConfiguration |   212.99 ns | 1.1049 ns | 0.8626 ns |           - |           - |           - |                   - |
|                       Remember_NoCacheForScope | 2,018.77 ns | 40.187 ns | 92.336 ns |      0.2852 |      0.0039 |           - |              1200 B |
|                                       Remember | 1,549.72 ns | 33.164 ns | 32.572 ns |      0.0273 |      0.0078 |           - |               168 B |
|        Release_InstanceNotFound_SingleThreaded |   993.08 ns | 19.669 ns | 29.440 ns |      0.0605 |           - |           - |               256 B |
|         Release_InstanceNotFound_MultiThreaded |   789.38 ns | 15.619 ns | 16.040 ns |      0.0614 |           - |           - |                   - |
|              RememberAndRelease_Singlethreaded | 2,192.04 ns | 42.820 ns | 43.973 ns |      0.1450 |      0.0038 |           - |               616 B |
|               RememberAndRelease_Multithreaded | 3,003.57 ns | 56.312 ns | 57.829 ns |      0.1450 |      0.0050 |           - |                   - |
