### PR TITLE
Changed StandardConstructorScorer.GetTargetType((ITarget target) to static

### DIFF
--- a/src/Ninject.Benchmarks/Selection/Heuristics/StandardConstructorScorerBenchmark.cs
+++ b/src/Ninject.Benchmarks/Selection/Heuristics/StandardConstructorScorerBenchmark.cs
@@ -14,6 +14,7 @@ using Ninject.Planning.Directives;
 using Ninject.Selection.Heuristics;
 using Ninject.Tests.Fakes;
 using Ninject.Tests.Integration;
+using Ninject.Tests.Integration.EnumerableDependenciesTests.Fakes;
 
 namespace Ninject.Benchmarks.Selection.Heuristics
 {
@@ -36,6 +37,8 @@ namespace Ninject.Benchmarks.Selection.Heuristics
         private ConstructorInjectionDirective _barracksCtorDirective;
         private ConstructorInfo _monasteryCtor;
         private ConstructorInjectionDirective _monasteryCtorDirective;
+        private ConstructorInfo _enumerableCtor;
+        private ConstructorInjectionDirective _enumerableCtorDirective;
         private StandardConstructorScorer _standardConstructorScorer;
         private IInjectorFactory _injectorFactory;
         private Context _contextWithParams;
@@ -97,6 +100,9 @@ namespace Ninject.Benchmarks.Selection.Heuristics
             _monasteryCtor = typeof(Monastery).GetConstructor(new[] { typeof(IWarrior), typeof(IWeapon) });
             _monasteryCtorDirective = new ConstructorInjectionDirective(_monasteryCtor, _injectorFactory.Create(_monasteryCtor));
 
+            _enumerableCtor = typeof(RequestsEnumerable).GetConstructor(new[] { typeof(IEnumerable<IChild>) });
+            _enumerableCtorDirective = new ConstructorInjectionDirective(_enumerableCtor, _injectorFactory.Create(_enumerableCtor));
+
             _standardConstructorScorer = new StandardConstructorScorer(ninjectSettings);
         }
 
@@ -128,6 +134,12 @@ namespace Ninject.Benchmarks.Selection.Heuristics
         public void OnlyBindings_DefaultValues()
         {
             _standardConstructorScorer.Score(_contextWithoutParams, _knifeDefaultsCtorDirective);
+        }
+
+        [Benchmark]
+        public void OnlyBindings_IEnumerable()
+        {
+            _standardConstructorScorer.Score(_contextWithoutParams, _enumerableCtorDirective);
         }
 
         [Benchmark]

--- a/src/Ninject/Selection/Heuristics/StandardConstructorScorer.cs
+++ b/src/Ninject/Selection/Heuristics/StandardConstructorScorer.cs
@@ -120,7 +120,7 @@ namespace Ninject.Selection.Heuristics
         /// <returns>Whether a binding exists for the target in the given context.</returns>
         protected virtual bool BindingExists(IReadOnlyKernel kernel, IContext context, ITarget target)
         {
-            var targetType = this.GetTargetType(target);
+            var targetType = GetTargetType(target);
 
             if (target.HasDefaultValue)
             {
@@ -162,7 +162,7 @@ namespace Ninject.Selection.Heuristics
             return false;
         }
 
-        private Type GetTargetType(ITarget target)
+        private static Type GetTargetType(ITarget target)
         {
             var targetType = target.Type;
 

--- a/src/Ninject/Selection/Heuristics/StandardConstructorScorer.cs
+++ b/src/Ninject/Selection/Heuristics/StandardConstructorScorer.cs
@@ -105,7 +105,10 @@ namespace Ninject.Selection.Heuristics
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="target">The target.</param>
-        /// <returns>Whether a binding exists for the target in the given context.</returns>
+        /// <returns>
+        /// <see langword="true"/> if a binding exists for the target in the given context; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         protected virtual bool BindingExists(IContext context, ITarget target)
         {
             return this.BindingExists(context.Kernel, context, target);
@@ -117,16 +120,18 @@ namespace Ninject.Selection.Heuristics
         /// <param name="kernel">The kernel.</param>
         /// <param name="context">The context.</param>
         /// <param name="target">The target.</param>
-        /// <returns>Whether a binding exists for the target in the given context.</returns>
+        /// <returns>
+        /// <see langword="true"/> if a binding exists for the target in the given context; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
         protected virtual bool BindingExists(IReadOnlyKernel kernel, IContext context, ITarget target)
         {
-            var targetType = GetTargetType(target);
-
             if (target.HasDefaultValue)
             {
                 return true;
             }
 
+            var targetType = GetTargetType(target);
             var bindings = kernel.GetBindings(targetType);
             if (bindings.Length > 0)
             {
@@ -148,7 +153,10 @@ namespace Ninject.Selection.Heuristics
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="target">The target.</param>
-        /// <returns>Whether a parameter exists for the target in the given context.</returns>
+        /// <returns>
+        /// <see langword="true"/> if a parameter exists for the target in the given context;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
         protected virtual bool ParameterExists(IContext context, ITarget target)
         {
             foreach (var parameter in context.Parameters)


### PR DESCRIPTION
Changed `StandardConstructorScorer.GetTargetType((ITarget target)` to be a static method.