### PR TITLE
Add fast Union and Concat extension methods.

### DIFF
--- a/src/Ninject.Benchmarks/Infrastructure/Language/ExtensionsForListBenchmark.cs
+++ b/src/Ninject.Benchmarks/Infrastructure/Language/ExtensionsForListBenchmark.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+
+using BenchmarkDotNet.Attributes;
+
+using Ninject.Infrastructure.Language;
+
+namespace Ninject.Benchmarks.Infrastructure.Language
+{
+    [MemoryDiagnoser]
+    public class ExtensionsForListBenchmark
+    {
+        private IReadOnlyList<object> _readOnlyListEmpty;
+        private List<object> _listEmpty;
+        private IReadOnlyList<object> _readOnlyListNotEmpty;
+        private List<object> _listNotEmpty;
+
+        public ExtensionsForListBenchmark()
+        {
+            var item1 = new object();
+            var item2 = new object();
+            var item3 = new object();
+            var item4 = new object();
+
+            _readOnlyListEmpty = Array.Empty<object>();
+            _listEmpty = new List<object>();
+
+            _readOnlyListNotEmpty = new[] { item1, item2, item1 };
+            _listNotEmpty = new List<object> { item3, item4, item3 };
+        }
+
+        [Benchmark]
+        public void Concat_IReadOnlyListAndIList_FirstAndSecondEmpty()
+        {
+            _readOnlyListEmpty.Concat(_listEmpty);
+        }
+
+        [Benchmark]
+        public void Concat_IReadOnlyListAndIList_FirstEmpty()
+        {
+            _readOnlyListEmpty.Concat(_listNotEmpty);
+        }
+
+        [Benchmark]
+        public void Concat_IReadOnlyListAndIList_SecondEmpty()
+        {
+            _readOnlyListNotEmpty.Concat(_listEmpty);
+        }
+
+        [Benchmark]
+        public void Concat_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty()
+        {
+            _readOnlyListNotEmpty.Concat(_listNotEmpty);
+        }
+
+        [Benchmark]
+        public void Union_IReadOnlyListAndIList_FirstAndSecondEmpty()
+        {
+            _readOnlyListEmpty.Union(_listEmpty);
+        }
+
+        [Benchmark]
+        public void Union_IReadOnlyListAndIList_FirstEmpty()
+        {
+            _readOnlyListEmpty.Union(_listNotEmpty);
+        }
+
+        [Benchmark]
+        public void Union_IReadOnlyListAndIList_SecondEmpty()
+        {
+            _readOnlyListNotEmpty.Union(_listEmpty);
+        }
+
+        [Benchmark]
+        public void Union_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty()
+        {
+            _readOnlyListNotEmpty.Union(_listNotEmpty);
+        }
+
+        [Benchmark]
+        public void LinqUnion_IReadOnlyListAndIList_FirstAndSecondEmpty()
+        {
+            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListEmpty, _listEmpty));
+        }
+
+        [Benchmark]
+        public void LinqUnion_IReadOnlyListAndIList_FirstEmpty()
+        {
+            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListEmpty, _listNotEmpty));
+        }
+
+        [Benchmark]
+        public void LinqUnion_IReadOnlyListAndIList_SecondEmpty()
+        {
+            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListNotEmpty, _listEmpty));
+        }
+
+        [Benchmark]
+        public void LinqUnion_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty()
+        {
+            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListNotEmpty, _listNotEmpty));
+        }
+    }
+}

--- a/src/Ninject.Benchmarks/Infrastructure/Language/ExtensionsForListBenchmark.cs
+++ b/src/Ninject.Benchmarks/Infrastructure/Language/ExtensionsForListBenchmark.cs
@@ -76,29 +76,5 @@ namespace Ninject.Benchmarks.Infrastructure.Language
         {
             _readOnlyListNotEmpty.Union(_listNotEmpty);
         }
-
-        [Benchmark]
-        public void LinqUnion_IReadOnlyListAndIList_FirstAndSecondEmpty()
-        {
-            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListEmpty, _listEmpty));
-        }
-
-        [Benchmark]
-        public void LinqUnion_IReadOnlyListAndIList_FirstEmpty()
-        {
-            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListEmpty, _listNotEmpty));
-        }
-
-        [Benchmark]
-        public void LinqUnion_IReadOnlyListAndIList_SecondEmpty()
-        {
-            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListNotEmpty, _listEmpty));
-        }
-
-        [Benchmark]
-        public void LinqUnion_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty()
-        {
-            System.Linq.Enumerable.ToList(System.Linq.Enumerable.Union(_readOnlyListNotEmpty, _listNotEmpty));
-        }
     }
 }

--- a/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForListTests.cs
+++ b/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForListTests.cs
@@ -1,7 +1,7 @@
 ﻿using Ninject.Infrastructure.Language;
 using System;
 using System.Collections.Generic;
-//using System.Linq;
+using System.Linq;
 using Xunit;
 
 namespace Ninject.Tests.Unit.Infrastructure.Language
@@ -30,102 +30,106 @@ namespace Ninject.Tests.Unit.Infrastructure.Language
         [Fact]
         public void Union_IReadOnlyListAndIList_FirstEmpty()
         {
-            var secondItem1 = _random.Next(1, 10);
-            var secondItem2 = _random.Next(11, 20);
+            var secondItem1 = new object();
+            var secondItem2 = new object();
+            var secondItem3 = new object();
 
-            IReadOnlyList<int> first = Array.Empty<int>();
-            IList<int> second = new[] { secondItem1, secondItem2 };
+            IReadOnlyList<object> first = Array.Empty<object>();
+            IList<object> second = new[] { secondItem1, secondItem2, secondItem3, secondItem2 };
 
-            var actual = first.Union(second);
+            var actual = first.Union(second).ToArray();
 
             Assert.NotNull(actual);
-            Assert.Equal(second, actual);
-            Assert.NotSame(second, actual);
+            Assert.Equal(3, actual.Length);
+            Assert.Same(secondItem1, actual[0]);
+            Assert.Same(secondItem2, actual[1]);
+            Assert.Same(secondItem3, actual[2]);
         }
 
         [Fact]
         public void Union_IReadOnlyListAndIList_SecondEmpty()
         {
-            var firstItem1 = _random.Next(1, 10);
-            var firstItem2 = _random.Next(11, 20);
+            var firstItem1 = new object();
+            var firstItem2 = new object();
 
-            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
-            IList<int> second = Array.Empty<int>();
+            IReadOnlyList<object> first = new[] { firstItem1, firstItem2, firstItem1 };
+            IList<object> second = Array.Empty<object>();
 
-            var actual = first.Union(second);
+            var actual = first.Union(second).ToArray(); ;
 
             Assert.NotNull(actual);
-            Assert.Equal(first, actual);
-            Assert.NotSame(first, actual);
+            Assert.Equal(2, actual.Length);
+            Assert.Same(firstItem1, actual[0]);
+            Assert.Same(firstItem2, actual[1]);
         }
 
         [Fact]
         public void Union_IReadOnlyListAndIList_FirstContainsDuplicates()
         {
-            var firstItem1 = _random.Next(1, 10);
-            var firstItem2 = _random.Next(11, 20);
-            var firstItem3 = _random.Next(21, 30);
-            var secondItem1 = _random.Next(31, 40);
-            var secondItem2 = _random.Next(41, 50);
+            var firstItem1 = new object();
+            var firstItem2 = new object();
+            var firstItem3 = new object();
+            var secondItem1 = new object();
+            var secondItem2 = new object();
 
-            IReadOnlyList<int> first = new[] { firstItem1, firstItem2, firstItem1, firstItem3 };
-            IList<int> second = new[] { secondItem1, secondItem2 };
+            IReadOnlyList<object> first = new[] { firstItem1, firstItem2, firstItem1, firstItem3 };
+            IList<object> second = new[] { secondItem1, secondItem2 };
 
-            var actual = first.Union(second);
+            var actual = first.Union(second).ToArray(); ;
 
             Assert.NotNull(actual);
-            Assert.Equal(5, actual.Count);
-            Assert.Equal(firstItem1, actual[0]);
-            Assert.Equal(firstItem2, actual[1]);
-            Assert.Equal(firstItem3, actual[2]);
-            Assert.Equal(secondItem1, actual[3]);
-            Assert.Equal(secondItem2, actual[4]);
+            Assert.Equal(5, actual.Length);
+            Assert.Same(firstItem1, actual[0]);
+            Assert.Same(firstItem2, actual[1]);
+            Assert.Same(firstItem3, actual[2]);
+            Assert.Same(secondItem1, actual[3]);
+            Assert.Same(secondItem2, actual[4]);
         }
 
         [Fact]
         public void Union_IReadOnlyListAndIList_SecondContainsDuplicates()
         {
-            var firstItem1 = _random.Next(1, 10);
-            var firstItem2 = _random.Next(11, 20);
-            var secondItem1 = _random.Next(21, 30);
-            var secondItem2 = _random.Next(31, 40);
-            var secondItem3 = _random.Next(41, 50);
+            var firstItem1 = new object();
+            var firstItem2 = new object();
+            var secondItem1 = new object();
+            var secondItem2 = new object();
+            var secondItem3 = new object();
 
-            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
-            IList<int> second = new[] { secondItem1, secondItem2, secondItem1, secondItem3 };
+            IReadOnlyList<object> first = new[] { firstItem1, firstItem2 };
+            IList<object> second = new[] { secondItem1, secondItem2, secondItem1, secondItem3 };
 
-            var actual = first.Union(second);
+            var actual = first.Union(second).ToArray(); ;
 
             Assert.NotNull(actual);
-            Assert.Equal(5, actual.Count);
-            Assert.Equal(firstItem1, actual[0]);
-            Assert.Equal(firstItem2, actual[1]);
-            Assert.Equal(secondItem1, actual[2]);
-            Assert.Equal(secondItem2, actual[3]);
-            Assert.Equal(secondItem3, actual[4]);
+            Assert.Equal(5, actual.Length);
+            Assert.Same(firstItem1, actual[0]);
+            Assert.Same(firstItem2, actual[1]);
+            Assert.Same(secondItem1, actual[2]);
+            Assert.Same(secondItem2, actual[3]);
+            Assert.Same(secondItem3, actual[4]);
         }
 
         [Fact]
         public void Union_IReadOnlyListAndIList_DuplicatesInUnion()
         {
-            var firstItem1 = _random.Next(1, 10);
-            var firstItem2 = _random.Next(11, 20);
-            var secondItem1 = _random.Next(21, 30);
-            var secondItem2 = _random.Next(31, 40);
-            var secondItem3 = _random.Next(41, 50);
+            var firstItem1 = new object();
+            var firstItem2 = new object();
+            var secondItem1 = new object();
+            var secondItem2 = new object();
+            var secondItem3 = new object();
 
-            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
-            IList<int> second = new[] { secondItem1, secondItem2, firstItem1, secondItem3 };
+            IReadOnlyList<object> first = new[] { firstItem1, firstItem2, firstItem2};
+            IList<object> second = new[] { secondItem1, secondItem2, firstItem1, secondItem3 };
 
-            var actual = first.Union(second);
+            var actual = first.Union(second).ToArray(); ;
 
             Assert.NotNull(actual);
-            Assert.Equal(5, actual.Count);
-            Assert.Equal(firstItem1, actual[0]);
-            Assert.Equal(firstItem2, actual[1]);
-            Assert.Equal(secondItem1, actual[2]);
-            Assert.Equal(secondItem2, actual[3]);
-            Assert.Equal(secondItem3, actual[4]);
+            Assert.Equal(5, actual.Length);
+            Assert.Same(firstItem1, actual[0]);
+            Assert.Same(firstItem2, actual[1]);
+            Assert.Same(secondItem1, actual[2]);
+            Assert.Same(secondItem2, actual[3]);
+            Assert.Same(secondItem3, actual[4]);
         }
 
         [Fact]

--- a/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForListTests.cs
+++ b/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForListTests.cs
@@ -79,11 +79,11 @@ namespace Ninject.Tests.Unit.Infrastructure.Language
 
             Assert.NotNull(actual);
             Assert.Equal(5, actual.Length);
-            Assert.Same(firstItem1, actual[0]);
-            Assert.Same(firstItem2, actual[1]);
-            Assert.Same(firstItem3, actual[2]);
-            Assert.Same(secondItem1, actual[3]);
-            Assert.Same(secondItem2, actual[4]);
+            Assert.Contains(firstItem1, actual);
+            Assert.Contains(firstItem2, actual);
+            Assert.Contains(firstItem3, actual);
+            Assert.Contains(secondItem1, actual);
+            Assert.Contains(secondItem2, actual);
         }
 
         [Fact]
@@ -102,11 +102,11 @@ namespace Ninject.Tests.Unit.Infrastructure.Language
 
             Assert.NotNull(actual);
             Assert.Equal(5, actual.Length);
-            Assert.Same(firstItem1, actual[0]);
-            Assert.Same(firstItem2, actual[1]);
-            Assert.Same(secondItem1, actual[2]);
-            Assert.Same(secondItem2, actual[3]);
-            Assert.Same(secondItem3, actual[4]);
+            Assert.Contains(firstItem1, actual);
+            Assert.Contains(firstItem2, actual);
+            Assert.Contains(secondItem1, actual);
+            Assert.Contains(secondItem2, actual);
+            Assert.Contains(secondItem3, actual);
         }
 
         [Fact]
@@ -125,11 +125,11 @@ namespace Ninject.Tests.Unit.Infrastructure.Language
 
             Assert.NotNull(actual);
             Assert.Equal(5, actual.Length);
-            Assert.Same(firstItem1, actual[0]);
-            Assert.Same(firstItem2, actual[1]);
-            Assert.Same(secondItem1, actual[2]);
-            Assert.Same(secondItem2, actual[3]);
-            Assert.Same(secondItem3, actual[4]);
+            Assert.Contains(firstItem1, actual);
+            Assert.Contains(firstItem2, actual);
+            Assert.Contains(secondItem1, actual);
+            Assert.Contains(secondItem2, actual);
+            Assert.Contains(secondItem3, actual);
         }
 
         [Fact]

--- a/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForListTests.cs
+++ b/src/Ninject.Test/Unit/Infrastructure/Language/ExtensionsForListTests.cs
@@ -1,0 +1,246 @@
+﻿using Ninject.Infrastructure.Language;
+using System;
+using System.Collections.Generic;
+//using System.Linq;
+using Xunit;
+
+namespace Ninject.Tests.Unit.Infrastructure.Language
+{
+    public class ExtensionsForListTests
+    {
+        private Random _random;
+
+        public ExtensionsForListTests()
+        {
+            _random = new Random();
+        }
+
+        [Fact]
+        public void Union_IReadOnlyListAndIList_FirstAndSecondEmpty()
+        {
+            IReadOnlyList<string> first = Array.Empty<string>();
+            IList<string> second = Array.Empty<string>();
+
+            var actual = first.Union(second);
+
+            Assert.NotNull(actual);
+            Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void Union_IReadOnlyListAndIList_FirstEmpty()
+        {
+            var secondItem1 = _random.Next(1, 10);
+            var secondItem2 = _random.Next(11, 20);
+
+            IReadOnlyList<int> first = Array.Empty<int>();
+            IList<int> second = new[] { secondItem1, secondItem2 };
+
+            var actual = first.Union(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(second, actual);
+            Assert.NotSame(second, actual);
+        }
+
+        [Fact]
+        public void Union_IReadOnlyListAndIList_SecondEmpty()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
+            IList<int> second = Array.Empty<int>();
+
+            var actual = first.Union(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(first, actual);
+            Assert.NotSame(first, actual);
+        }
+
+        [Fact]
+        public void Union_IReadOnlyListAndIList_FirstContainsDuplicates()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+            var firstItem3 = _random.Next(21, 30);
+            var secondItem1 = _random.Next(31, 40);
+            var secondItem2 = _random.Next(41, 50);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2, firstItem1, firstItem3 };
+            IList<int> second = new[] { secondItem1, secondItem2 };
+
+            var actual = first.Union(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(5, actual.Count);
+            Assert.Equal(firstItem1, actual[0]);
+            Assert.Equal(firstItem2, actual[1]);
+            Assert.Equal(firstItem3, actual[2]);
+            Assert.Equal(secondItem1, actual[3]);
+            Assert.Equal(secondItem2, actual[4]);
+        }
+
+        [Fact]
+        public void Union_IReadOnlyListAndIList_SecondContainsDuplicates()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+            var secondItem1 = _random.Next(21, 30);
+            var secondItem2 = _random.Next(31, 40);
+            var secondItem3 = _random.Next(41, 50);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
+            IList<int> second = new[] { secondItem1, secondItem2, secondItem1, secondItem3 };
+
+            var actual = first.Union(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(5, actual.Count);
+            Assert.Equal(firstItem1, actual[0]);
+            Assert.Equal(firstItem2, actual[1]);
+            Assert.Equal(secondItem1, actual[2]);
+            Assert.Equal(secondItem2, actual[3]);
+            Assert.Equal(secondItem3, actual[4]);
+        }
+
+        [Fact]
+        public void Union_IReadOnlyListAndIList_DuplicatesInUnion()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+            var secondItem1 = _random.Next(21, 30);
+            var secondItem2 = _random.Next(31, 40);
+            var secondItem3 = _random.Next(41, 50);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
+            IList<int> second = new[] { secondItem1, secondItem2, firstItem1, secondItem3 };
+
+            var actual = first.Union(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(5, actual.Count);
+            Assert.Equal(firstItem1, actual[0]);
+            Assert.Equal(firstItem2, actual[1]);
+            Assert.Equal(secondItem1, actual[2]);
+            Assert.Equal(secondItem2, actual[3]);
+            Assert.Equal(secondItem3, actual[4]);
+        }
+
+        [Fact]
+        public void Concat_IReadOnlyListAndIList_FirstAndSecondEmpty()
+        {
+            IReadOnlyList<string> first = Array.Empty<string>();
+            IList<string> second = Array.Empty<string>();
+
+            var actual = first.Concat(second);
+
+            Assert.NotNull(actual);
+            Assert.Empty(actual);
+        }
+
+        [Fact]
+        public void Concat_IReadOnlyListAndIList_FirstEmpty()
+        {
+            var secondItem1 = _random.Next(1, 10);
+            var secondItem2 = _random.Next(11, 20);
+
+            IReadOnlyList<int> first = Array.Empty<int>();
+            IList<int> second = new[] { secondItem1, secondItem2 };
+
+            var actual = first.Concat(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(second, actual);
+            Assert.NotSame(second, actual);
+        }
+
+        [Fact]
+        public void Concat_IReadOnlyListAndIList_SecondEmpty()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
+            IList<int> second = Array.Empty<int>();
+
+            var actual = first.Concat(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(first, actual);
+            Assert.Same(first, actual);
+        }
+
+        [Fact]
+        public void Concat_IReadOnlyListAndIList_FirstContainsDuplicates()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+            var firstItem3 = _random.Next(21, 30);
+            var secondItem1 = _random.Next(31, 40);
+            var secondItem2 = _random.Next(41, 50);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2, firstItem1, firstItem3 };
+            IList<int> second = new[] { secondItem1, secondItem2 };
+
+            var actual = first.Concat(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(6, actual.Count);
+            Assert.Equal(firstItem1, actual[0]);
+            Assert.Equal(firstItem2, actual[1]);
+            Assert.Equal(firstItem1, actual[2]);
+            Assert.Equal(firstItem3, actual[3]);
+            Assert.Equal(secondItem1, actual[4]);
+            Assert.Equal(secondItem2, actual[5]);
+        }
+
+        [Fact]
+        public void Concat_IReadOnlyListAndIList_SecondContainsDuplicates()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+            var secondItem1 = _random.Next(21, 40);
+            var secondItem2 = _random.Next(31, 40);
+            var secondItem3 = _random.Next(41, 50);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
+            IList<int> second = new[] { secondItem1, secondItem2, secondItem1, secondItem3 };
+
+            var actual = first.Concat(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(6, actual.Count);
+            Assert.Equal(firstItem1, actual[0]);
+            Assert.Equal(firstItem2, actual[1]);
+            Assert.Equal(secondItem1, actual[2]);
+            Assert.Equal(secondItem2, actual[3]);
+            Assert.Equal(secondItem1, actual[4]);
+        }
+
+        [Fact]
+        public void Concat_IReadOnlyListAndIList_DuplicatesInUnion()
+        {
+            var firstItem1 = _random.Next(1, 10);
+            var firstItem2 = _random.Next(11, 20);
+            var secondItem1 = _random.Next(21, 40);
+            var secondItem2 = _random.Next(31, 40);
+            var secondItem3 = _random.Next(41, 50);
+
+            IReadOnlyList<int> first = new[] { firstItem1, firstItem2 };
+            IList<int> second = new[] { secondItem1, secondItem2, firstItem1, secondItem3 };
+
+            var actual = first.Concat(second);
+
+            Assert.NotNull(actual);
+            Assert.Equal(6, actual.Count);
+            Assert.Equal(firstItem1, actual[0]);
+            Assert.Equal(firstItem2, actual[1]);
+            Assert.Equal(secondItem1, actual[2]);
+            Assert.Equal(secondItem2, actual[3]);
+            Assert.Equal(firstItem1, actual[4]);
+            Assert.Equal(secondItem3, actual[5]);
+        }
+    }
+}

--- a/src/Ninject/Infrastructure/Language/ExtensionsForList.cs
+++ b/src/Ninject/Infrastructure/Language/ExtensionsForList.cs
@@ -1,0 +1,124 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="ExtensionsForList.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2007-2010 Enkari, Ltd. All rights reserved.
+//   Copyright (c) 2010-2017 Ninject Project Contributors. All rights reserved.
+//
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   You may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace Ninject.Infrastructure.Language
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Enumerable = System.Linq.Enumerable;
+
+    /// <summary>
+    /// Provides extension methods for <see cref="IList{T}"/> and <see cref="IReadOnlyList{T}"/>.
+    /// </summary>
+    internal static class ExtensionsForList
+    {
+        /// <summary>
+        /// Produces the set union of two lists by using the default equality comparer.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the input lists.</typeparam>
+        /// <param name="first">An <see cref="IReadOnlyList{T}"/> whose distinct elements form the first set for the union.</param>
+        /// <param name="second">An <see cref="ICollection{T}"/> whose distinct elements form the second set for the union.</param>
+        /// <returns>
+        /// An <see cref="IReadOnlyList{T}"/> that contains the elements from both input lists, excluding duplicates.
+        /// </returns>
+        /// <exception cref="NullReferenceException"><paramref name="second"/> is <see langword="null"/>.</exception>
+        /// <exception cref="NullReferenceException"><paramref name="second"/> is not empy, and <paramref name="first"/> is <see langword="null"/>.</exception>
+        public static IReadOnlyList<T> Union<T>(this IReadOnlyList<T> first, ICollection<T> second)
+        {
+            var numberItemsInSecond = second.Count;
+
+            if (numberItemsInSecond == 0)
+            {
+                if (first.Count == 0)
+                {
+                    return first;
+                }
+                else
+                {
+                    var set = new HashSet<T>(first);
+                    var union = new T[set.Count];
+                    set.CopyTo(union);
+                    return union;
+                }
+            }
+            else
+            {
+                return Enumerable.ToList(Enumerable.Union(first, second));
+            }
+        }
+
+        /// <summary>
+        /// Concatenates two lists.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the input lists.</typeparam>
+        /// <param name="first">The first list to concatenate.</param>
+        /// <param name="second">The second list to concatenate.</param>
+        /// <returns>
+        /// An <see cref="IReadOnlyList{T}"/> that contains the concatenated elements of the two input lists.
+        /// </returns>
+        /// <exception cref="NullReferenceException"><paramref name="second"/> is <see langword="null"/>.</exception>
+        /// <exception cref="NullReferenceException"><paramref name="second"/> is not empy, and <paramref name="first"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// When <paramref name="second"/> is empty, then <paramref name="first"/> will be returned as is (without making
+        /// a copy).
+        /// </remarks>
+        public static IReadOnlyList<T> Concat<T>(this IReadOnlyList<T> first, IList<T> second)
+        {
+            var numberItemsInSecond = second.Count;
+
+            if (numberItemsInSecond == 0)
+            {
+                return first;
+            }
+            else
+            {
+                T[] union;
+                var numberItemsInFirst = first.Count;
+
+                if (numberItemsInFirst == 0)
+                {
+                    union = new T[numberItemsInSecond];
+                    for (var i = 0; i < numberItemsInSecond; i++)
+                    {
+                        union[i] = second[i];
+                    }
+                }
+                else
+                {
+                    union = new T[numberItemsInFirst + numberItemsInSecond];
+
+                    for (var i = 0; i < numberItemsInFirst; i++)
+                    {
+                        union[i] = first[i];
+                    }
+
+                    for (var i = 0; i < numberItemsInSecond; i++)
+                    {
+                        union[i + numberItemsInFirst] = second[i];
+                    }
+                }
+
+                return union;
+            }
+        }
+    }
+}

--- a/src/Ninject/Infrastructure/Language/ExtensionsForList.cs
+++ b/src/Ninject/Infrastructure/Language/ExtensionsForList.cs
@@ -24,8 +24,6 @@ namespace Ninject.Infrastructure.Language
     using System;
     using System.Collections.Generic;
 
-    using Enumerable = System.Linq.Enumerable;
-
     /// <summary>
     /// Provides extension methods for <see cref="IList{T}"/> and <see cref="IReadOnlyList{T}"/>.
     /// </summary>
@@ -42,7 +40,7 @@ namespace Ninject.Infrastructure.Language
         /// </returns>
         /// <exception cref="NullReferenceException"><paramref name="second"/> is <see langword="null"/>.</exception>
         /// <exception cref="NullReferenceException"><paramref name="second"/> is not empy, and <paramref name="first"/> is <see langword="null"/>.</exception>
-        public static IReadOnlyList<T> Union<T>(this IReadOnlyList<T> first, ICollection<T> second)
+        public static IReadOnlyCollection<T> Union<T>(this IReadOnlyList<T> first, ICollection<T> second)
         {
             var numberItemsInSecond = second.Count;
 
@@ -54,23 +52,21 @@ namespace Ninject.Infrastructure.Language
                 }
                 else
                 {
-                    var set = new HashSet<T>(first);
-                    var union = new T[set.Count];
-                    set.CopyTo(union);
-                    return union;
+                    return new HashSet<T>(first);
                 }
             }
             else
             {
-                if (first.Count == 0)
+                var union = new HashSet<T>(second);
+                if (first.Count > 0)
                 {
-                    var set = new HashSet<T>(first);
-                    var union = new T[set.Count];
-                    set.CopyTo(union);
-                    return union;
+                    foreach (var firstItem in first)
+                    {
+                        union.Add(firstItem);
+                    }
                 }
 
-                return Enumerable.ToList(Enumerable.Union(first, second));
+                return union;
             }
         }
 
@@ -99,33 +95,33 @@ namespace Ninject.Infrastructure.Language
             }
             else
             {
-                T[] union;
+                T[] concat;
                 var numberItemsInFirst = first.Count;
 
                 if (numberItemsInFirst == 0)
                 {
-                    union = new T[numberItemsInSecond];
+                    concat = new T[numberItemsInSecond];
                     for (var i = 0; i < numberItemsInSecond; i++)
                     {
-                        union[i] = second[i];
+                        concat[i] = second[i];
                     }
                 }
                 else
                 {
-                    union = new T[numberItemsInFirst + numberItemsInSecond];
+                    concat = new T[numberItemsInFirst + numberItemsInSecond];
 
                     for (var i = 0; i < numberItemsInFirst; i++)
                     {
-                        union[i] = first[i];
+                        concat[i] = first[i];
                     }
 
                     for (var i = 0; i < numberItemsInSecond; i++)
                     {
-                        union[i + numberItemsInFirst] = second[i];
+                        concat[i + numberItemsInFirst] = second[i];
                     }
                 }
 
-                return union;
+                return concat;
             }
         }
     }

--- a/src/Ninject/Infrastructure/Language/ExtensionsForList.cs
+++ b/src/Ninject/Infrastructure/Language/ExtensionsForList.cs
@@ -62,6 +62,14 @@ namespace Ninject.Infrastructure.Language
             }
             else
             {
+                if (first.Count == 0)
+                {
+                    var set = new HashSet<T>(first);
+                    var union = new T[set.Count];
+                    set.CopyTo(union);
+                    return union;
+                }
+
                 return Enumerable.ToList(Enumerable.Union(first, second));
             }
         }


### PR DESCRIPTION
* Adds fast Union and Concat extension methods for **IReadOnlyList\<T>**.
  The methods will be used in future PRs.

**Concat benchmarks:**

| Method |   Version |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------------------------------------- |----------:|----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|          Concat_IReadOnlyListAndIList_FirstAndSecondEmpty |      Linq | 231.51 ns | 1.7821 ns | 1.5798 ns |      0.0129 |           - |           - |                56 B |
|          Concat_IReadOnlyListAndIList_FirstAndSecondEmpty |        PR |  21.48 ns | 0.1301 ns | 0.1217 ns |           - |           - |           - |                   - |          
|                   Concat_IReadOnlyListAndIList_FirstEmpty |      Linq | 381.26 ns | 2.2775 ns | 2.1304 ns |      0.0377 |           - |           - |               160 B |
|                   Concat_IReadOnlyListAndIList_FirstEmpty |        PR |  99.31 ns | 0.6066 ns | 0.5675 ns |      0.0113 |           - |           - |                48 B |                   
|                  Concat_IReadOnlyListAndIList_SecondEmpty |      Linq | 392.36 ns | 2.9977 ns | 2.8041 ns |      0.0377 |           - |           - |               160 B |
|                  Concat_IReadOnlyListAndIList_SecondEmpty |        PR |  21.45 ns | 0.1392 ns | 0.1302 ns |           - |           - |           - |                   - |                  
|    Concat_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty |      Linq | 465.83 ns | 2.2929 ns | 2.1448 ns |      0.0434 |           - |           - |               184 B |
|    Concat_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty |        PR | 129.24 ns | 0.8132 ns | 0.7607 ns |      0.0169 |           - |           - |                72 B |
    
**Union benchmarks:**    
    
|                                                    Method |   Version |      Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|---------------------------------------------------------- |----------:|----------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
|           Union_IReadOnlyListAndIList_FirstAndSecondEmpty |      Linq | 370.88 ns | 0.8023 ns | 0.7112 ns |      0.0930 |           - |           - |               392 B |
|        Union_IReadOnlyListAndIList_FirstAndSecondEmpty | PR |  26.64 ns |  0.0703 ns |  0.0657 ns |  26.64 ns |           - |           - |           - |                   - |
|                    Union_IReadOnlyListAndIList_FirstEmpty |      Linq | 640.99 ns | 2.1698 ns | 2.0296 ns |      0.1030 |           - |           - |               432 B |
|                 Union_IReadOnlyListAndIList_FirstEmpty | PR | 499.82 ns |  3.4650 ns |  2.7052 ns | 499.84 ns |      0.0515 |           - |           - |               216 B |
|                   Union_IReadOnlyListAndIList_SecondEmpty |      Linq | 652.22 ns | 1.6178 ns | 1.5133 ns |      0.1097 |           - |           - |               464 B |
|                Union_IReadOnlyListAndIList_SecondEmpty | PR | 477.26 ns |  1.9915 ns |  1.7654 ns | 477.02 ns |      0.0486 |           - |           - |               208 B |
|     Union_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty |      Linq | 910.71 ns | 6.4324 ns | 5.3714 ns |      0.1135 |           - |           - |               480 B |    
|  Union_IReadOnlyListAndIList_FirstAndSecondAreNotEmpty | PR | 941.81 ns | 15.8103 ns | 13.2023 ns | 938.05 ns |      0.1040 |           - |           - |               440 B |