### PR TITLE
Improve performance for resolving a single instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed type of parameters argument in ReadOnlyKernel.CreateRequest(...) from IEnumerable<IParameter> to IReadOnlyList<IParameter>.
 - Changed type of Parameters property in IBindingConfiguration (and implementing classes) from ICollection<IParameter> to IList<IParameter>.
 - Changed type of Parameters property in Request and Context from IEnumerable<IParameter> to IReadOnlyList<IParameter>.
+- Added a `object ResolveSingle(IRequest request)` method to IResolutionRoot which is optimized for resolving a single instance of a given service.
+  This new method is used in the Get, TryGet and TryGetAndThrowOnInvalidBinding extension method.
 
 ### Fixed
 - Call `kernel.Get<T>()` two times do not give the same result [#262](https://github.com/ninject/Ninject/issues/262)

--- a/src/Ninject.Test/Unit/Activation/Providers/StandardProviderTests.cs
+++ b/src/Ninject.Test/Unit/Activation/Providers/StandardProviderTests.cs
@@ -139,54 +139,6 @@ namespace Ninject.Test.Unit.Activation.Providers
         }
 
         [Fact]
-        public void Create_ShouldThrowInvalidOperationExceptionWhenNoConstructorArgumentIsAvailableForGivenParameterAndResolveReturnsMultipleResults()
-        {
-            var seq = new MockSequence();
-
-            var injectorOneMock = new Mock<ConstructorInjector>(MockBehavior.Strict);
-            var injectorTwoMock = new Mock<ConstructorInjector>(MockBehavior.Strict);
-            var directiveOne = new ConstructorInjectionDirective(GetMyServiceWeaponAndWarriorConstructor(), injectorOneMock.Object);
-            var directiveTwo = new ConstructorInjectionDirective(GetMyServiceClericAndName(), injectorTwoMock.Object);
-            var readOnlyKernelMock = new Mock<IReadOnlyKernel>(MockBehavior.Strict);
-            var childRequestMock = new Mock<IRequest>(MockBehavior.Strict);
-            var planMock = new Mock<IPlan>(MockBehavior.Strict);
-            var instance = new object();
-            var weaponMock = new Mock<IWeapon>(MockBehavior.Strict);
-            var warriorMock = new Mock<IWarrior>(MockBehavior.Strict);
-            var directives = new[]
-
-                {
-                    directiveOne,
-                    directiveTwo
-                };
-
-            var parameters = new List<IParameter>
-                {
-                    new ConstructorArgument("name", "Foo"),
-                    new ConstructorArgument("weapon", weaponMock.Object),
-                    new ConstructorArgument("cleric", new Monk()),
-                };
-
-            _contextMock.InSequence(seq).Setup(p => p.Plan).Returns(_planMock.Object);
-            _contextMock.InSequence(seq).Setup(p => p.Plan).Returns(_planMock.Object);
-            _planMock.InSequence(seq).Setup(p => p.GetAll< ConstructorInjectionDirective>()).Returns(directives);
-            _constructorScorerMock.InSequence(seq).Setup(p => p.Score(_contextMock.Object, directiveOne)).Returns(3);
-            _constructorScorerMock.InSequence(seq).Setup(p => p.Score(_contextMock.Object, directiveTwo)).Returns(2);
-            _contextMock.InSequence(seq).Setup(p => p.Parameters).Returns(parameters);
-            _contextMock.InSequence(seq).Setup(p => p.Parameters).Returns(parameters);
-            _contextMock.InSequence(seq).Setup(p => p.Request).Returns(_requestMock.Object);
-            _requestMock.InSequence(seq).Setup(p => p.CreateChild(typeof(IWarrior), _contextMock.Object, It.IsAny<ParameterTarget>())).Returns(childRequestMock.Object);
-            childRequestMock.InSequence(seq).SetupSet(p => p.IsUnique = true);
-            _contextMock.InSequence(seq).Setup(p => p.Kernel).Returns(readOnlyKernelMock.Object);
-            readOnlyKernelMock.InSequence(seq).Setup(p => p.Resolve(childRequestMock.Object)).Returns(new[] { warriorMock.Object, new FootSoldier() });
-
-            var actualException = Assert.Throws<InvalidOperationException>(() => _standardProvider.Create(_contextMock.Object));
-
-            Assert.Null(actualException.InnerException);
-            Assert.Equal("Sequence contains more than one element", actualException.Message);
-        }
-
-        [Fact]
         public void Create_ShouldPassResolvedObjectForGivenParameterWhenNoConstructorArgumentIsAvailableForParameterAndResolveReturnsSingleResult()
         {
             var seq = new MockSequence();
@@ -225,7 +177,7 @@ namespace Ninject.Test.Unit.Activation.Providers
             _requestMock.InSequence(seq).Setup(p => p.CreateChild(typeof(IWarrior), _contextMock.Object, It.IsAny<ParameterTarget>())).Returns(childRequestMock.Object);
             childRequestMock.InSequence(seq).SetupSet(p => p.IsUnique = true);
             _contextMock.InSequence(seq).Setup(p => p.Kernel).Returns(readOnlyKernelMock.Object);
-            readOnlyKernelMock.InSequence(seq).Setup(p => p.Resolve(childRequestMock.Object)).Returns(new[] { warriorMock.Object });
+            readOnlyKernelMock.InSequence(seq).Setup(p => p.ResolveSingle(childRequestMock.Object)).Returns(warriorMock.Object);
             injectorOneMock.InSequence(seq).Setup(p => p(weaponMock.Object, warriorMock.Object)).Returns(expected);
 
             var actual = _standardProvider.Create(_contextMock.Object);
@@ -271,7 +223,7 @@ namespace Ninject.Test.Unit.Activation.Providers
             _requestMock.InSequence(seq).Setup(p => p.CreateChild(typeof(IWarrior), _contextMock.Object, It.IsAny<ParameterTarget>())).Returns(childRequestMock.Object);
             childRequestMock.InSequence(seq).SetupSet(p => p.IsUnique = true);
             _contextMock.InSequence(seq).Setup(p => p.Kernel).Returns(readOnlyKernelMock.Object);
-            readOnlyKernelMock.InSequence(seq).Setup(p => p.Resolve(childRequestMock.Object)).Returns(Enumerable.Empty<object>());
+            readOnlyKernelMock.InSequence(seq).Setup(p => p.ResolveSingle(childRequestMock.Object)).Returns(null);
             injectorOneMock.InSequence(seq).Setup(p => p(weaponMock.Object, null)).Returns(expected);
 
             var actual = _standardProvider.Create(_contextMock.Object);

--- a/src/Ninject.Test/Unit/ReadOnlyKernelTests.cs
+++ b/src/Ninject.Test/Unit/ReadOnlyKernelTests.cs
@@ -29,8 +29,8 @@ namespace Ninject.Test.Unit
         protected Mock<IBindingResolver> BindingResolverMock2 { get; }
         protected Mock<IMissingBindingResolver> MissingBindingResolverMock1 { get; }
         protected Mock<IMissingBindingResolver> MissingBindingResolverMock2 { get; }
-        protected IEnumerable<IBindingResolver> BindingResolvers { get; }
-        protected IEnumerable<IMissingBindingResolver> MissingBindingResolvers { get; }
+        protected List<IBindingResolver> BindingResolvers { get; }
+        protected List<IMissingBindingResolver> MissingBindingResolvers { get; }
 
         public ReadOnlyKernelTests()
         {
@@ -305,8 +305,8 @@ namespace Ninject.Test.Unit
                                       IPipeline pipeline,
                                       IExceptionFormatter exceptionFormatter,
                                       IBindingPrecedenceComparer bindingPrecedenceComparer,
-                                      IEnumerable<IBindingResolver> bindingResolvers,
-                                      IEnumerable<IMissingBindingResolver> missingBindingResolvers)
+                                      List<IBindingResolver> bindingResolvers,
+                                      List<IMissingBindingResolver> missingBindingResolvers)
                 : base(settings,
                        bindings,
                        cache,

--- a/src/Ninject.Test/Unit/ResolutionExtensionsTests.cs
+++ b/src/Ninject.Test/Unit/ResolutionExtensionsTests.cs
@@ -386,103 +386,61 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void Get_RootAndParameters_NoInstancesOfService()
+        public void Get_RootAndParameters_ResolveReturnsNull()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>)null, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
+            var actual = ResolutionExtensions.Get<IWeapon>(root, parameters);
 
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains no elements", actual.Message);
+            Assert.Null(actual);
         }
 
         [Fact]
-        public void Get_RootAndParameters_SingleInstanceOfService()
+        public void Get_RootAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.Get<IWeapon>(root, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void Get_RootAndParameters_SingleInstanceNotOfService()
+        public void Get_RootAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>)null, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWarrior>(root, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void Get_RootAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>)null, parameters, false, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void Get_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, false, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -496,7 +454,7 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.Get<IWeapon>(root, parameters));
@@ -519,7 +477,7 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void Get_RootAndConstraintAndParameters_NoInstancesOfService()
+        public void Get_RootAndConstraintAndParameters_ResolveReturnsNull()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
@@ -530,97 +488,54 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
+            var actual = ResolutionExtensions.Get<IWeapon>(root, constraint, parameters);
 
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains no elements", actual.Message);
+            Assert.Null(actual);
         }
 
         [Fact]
-        public void Get_RootAndConstraintAndParameters_SingleInstanceOfService()
+        public void Get_RootAndConstraintAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.Get<IWeapon>(root, constraint, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void Get_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        public void Get_RootAndConstraintAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWarrior>(root, constraint, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void Get_RootAndConstraintAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            Func<IBindingMetadata, bool> constraint = (_) => true;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void Get_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            Func<IBindingMetadata, bool> constraint = (_) => true;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -635,7 +550,7 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.Get<IWeapon>(root, constraint, parameters));
@@ -658,108 +573,64 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void Get_RootAndNameAndParameters_NoInstancesOfService()
+        public void Get_RootAndNameAndParameter_ResolveReturnsNull()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
+            var actual = ResolutionExtensions.Get<IWeapon>(root, name, parameters);
 
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains no elements", actual.Message);
+            Assert.Null(actual);
         }
 
         [Fact]
-        public void Get_RootAndNameAndParameters_SingleInstanceOfService()
+        public void Get_RootAndNameAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.Get<IWeapon>(root, name, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void Get_RootAndNameAndParameters_SingleInstanceNotOfService()
+        public void Get_RootAndNameAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(string), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<string>(root, name, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(string).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void Get_RootAndNameAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            var name = "NAME";
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void Get_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            var name = "NAME";
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(string).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -774,7 +645,7 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, false, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.Get<IWeapon>(root, name, parameters));
@@ -796,18 +667,17 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGet_RootAndParameters_NoInstancesOfService()
+        public void TryGet_RootAndParameters_ResolvesToNull()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, parameters);
 
@@ -815,83 +685,43 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGet_RootAndParameters_SingleInstanceOfService()
+        public void TryGet_RootAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void TryGet_RootAndParameters_SingleInstanceNotOfService()
+        public void TryGet_RootAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>) null, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWarrior>(root, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void TryGet_RootAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGet<IWeapon>(root, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void TryGet_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWeapon>(root, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -905,7 +735,7 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, parameters);
@@ -928,19 +758,18 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGet_RootAndConstraintAndParameters_NoInstancesOfService()
+        public void TryGet_RootAndConstraintAndParameters_ResolvesToNull()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters);
 
@@ -948,87 +777,45 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGet_RootAndConstraintAndParameters_SingleInstanceOfService()
+        public void TryGet_RootAndConstraintAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void TryGet_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        public void TryGet_RootAndConstraintAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWarrior>(root, constraint, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void TryGet_RootAndConstraintAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            Func<IBindingMetadata, bool> constraint = (_) => true;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void TryGet_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            Func<IBindingMetadata, bool> constraint = (_) => true;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -1043,7 +830,7 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, constraint, parameters);
@@ -1066,19 +853,18 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGet_RootAndNameAndParameters_NoInstancesOfService()
+        public void TryGet_RootAndNameAndParameters_ResolvesToNull()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, name, parameters);
 
@@ -1086,87 +872,45 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGet_RootAndNameAndParameters_SingleInstanceOfService()
+        public void TryGet_RootAndNameAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, name, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void TryGet_RootAndNameAndParameters_SingleInstanceNotOfService()
+        public void TryGet_RootAndNameAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWarrior>(root, name, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void TryGet_RootAndNameAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            var name = "NAME";
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGet<IWeapon>(root, name, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void TryGet_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            var name = "NAME";
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGet<IWeapon>(root, name, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -1181,7 +925,7 @@ namespace Ninject.Test.Unit
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
                      .Returns(_requestMock.Object);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = ResolutionExtensions.TryGet<IWeapon>(root, name, parameters);
@@ -1203,11 +947,10 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_NoInstancesOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_ResolveReturnsNull()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
@@ -1215,8 +958,8 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
             var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters);
 
@@ -1224,11 +967,11 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_SingleInstanceOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
@@ -1236,21 +979,21 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_SingleInstanceNotOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), (Func<IBindingMetadata, bool>) null, parameters, true, true))
@@ -1258,57 +1001,13 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWarrior>(root, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _requestMock.InSequence(_sequence)
-                        .SetupSet(p => p.ForceUnique = true);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), (Func<IBindingMetadata, bool>) null, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _requestMock.InSequence(_sequence)
-                        .SetupSet(p => p.ForceUnique = true);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -1324,7 +1023,7 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, parameters));
@@ -1347,12 +1046,11 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_NoInstancesOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_ResolveReturnsNull()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = Enumerable.Empty<object>();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
@@ -1360,8 +1058,8 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
             var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters);
 
@@ -1369,12 +1067,12 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_SingleInstanceOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_ResolvesToInstanceOfService()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
@@ -1382,22 +1080,22 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_SingleInstanceNotOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_ResolvesToInstanceNotOfService()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), constraint, parameters, true, true))
@@ -1405,22 +1103,22 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWarrior>(root, constraint, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
+        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_ResolvesToInstanceNotOfService_ShouldThrowInvalidCastException()
         {
             var root = _rootMock.Object;
             Func<IBindingMetadata, bool> constraint = (_) => true;
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
+            var resolvedInstance = new Monk();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
@@ -1428,36 +1126,13 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndConstraintAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            Func<IBindingMetadata, bool> constraint = (_) => true;
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), constraint, parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _requestMock.InSequence(_sequence)
-                        .SetupSet(p => p.ForceUnique = true);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -1474,7 +1149,7 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, constraint, parameters));
@@ -1497,7 +1172,7 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_NoInstancesOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_ResolveReturnsNull()
         {
             var root = _rootMock.Object;
             var name = "NAME";
@@ -1510,8 +1185,8 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns(resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(null);
 
             var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters);
 
@@ -1519,12 +1194,12 @@ namespace Ninject.Test.Unit
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_SingleInstanceOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_ResolveReturnsInstanceOfService()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger() };
+            var resolvedInstance = new Dagger();
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
@@ -1532,22 +1207,22 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters);
 
             Assert.NotNull(actual);
-            Assert.Same(resolvedInstances[0], actual);
+            Assert.Same(resolvedInstance, actual);
         }
 
         [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_SingleInstanceNotOfService()
+        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_ResolveReturnsInstanceNotOfService()
         {
             var root = _rootMock.Object;
             var name = "NAME";
             var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { 5L };
+            var resolvedInstance = 5L;
 
             _rootMock.InSequence(_sequence)
                      .Setup(p => p.CreateRequest(typeof(IWarrior), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
@@ -1555,59 +1230,13 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
+                     .Returns(resolvedInstance);
 
             var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWarrior>(root, name, parameters));
 
             Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[0].GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
-        }
-
-        [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_MultipleInstancesOfService_ShouldThrowInvalidOperationException()
-        {
-            var root = _rootMock.Object;
-            var name = "NAME";
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Sword() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _requestMock.InSequence(_sequence)
-                        .SetupSet(p => p.ForceUnique = true);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidOperationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal("Sequence contains more than one element", actual.Message);
-        }
-
-        [Fact]
-        public void TryGetAndThrowOnInvalidBinding_RootAndNameAndParameters_MultipleInstancesNotOfService_ShouldThrowInvalidCastException()
-        {
-            var root = _rootMock.Object;
-            var name = "NAME";
-            var parameters = new IParameter[0];
-            var resolvedInstances = new object[] { new Dagger(), new Monk() };
-
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.CreateRequest(typeof(IWeapon), It.IsNotNull<Func<IBindingMetadata, bool>>(), parameters, true, true))
-                     .Returns(_requestMock.Object);
-            _requestMock.InSequence(_sequence)
-                        .SetupSet(p => p.ForceUnique = true);
-            _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
-                     .Returns((IEnumerable<object>) resolvedInstances);
-
-            var actual = Assert.Throws<InvalidCastException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters));
-
-            Assert.Null(actual.InnerException);
-            Assert.Equal($"Unable to cast object of type '{resolvedInstances[1].GetType().FullName}' to type '{typeof(IWeapon).FullName}'.", actual.Message);
+            Assert.Equal($"Unable to cast object of type '{resolvedInstance.GetType().FullName}' to type '{typeof(IWarrior).FullName}'.", actual.Message);
         }
 
         [Fact]
@@ -1624,7 +1253,7 @@ namespace Ninject.Test.Unit
             _requestMock.InSequence(_sequence)
                         .SetupSet(p => p.ForceUnique = true);
             _rootMock.InSequence(_sequence)
-                     .Setup(p => p.Resolve(_requestMock.Object))
+                     .Setup(p => p.ResolveSingle(_requestMock.Object))
                      .Throws(activationException);
 
             var actual = Assert.Throws<ActivationException>(() => ResolutionExtensions.TryGetAndThrowOnInvalidBinding<IWeapon>(root, name, parameters));

--- a/src/Ninject/Activation/Blocks/ActivationBlock.cs
+++ b/src/Ninject/Activation/Blocks/ActivationBlock.cs
@@ -105,6 +105,20 @@ namespace Ninject.Activation.Blocks
         }
 
         /// <summary>
+        /// Resolves an instance for the specified request.
+        /// </summary>
+        /// <param name="request">The request to resolve.</param>
+        /// <returns>
+        /// An instance that matches the request.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ActivationException">More than one matching bindings is available for the request, and <see cref="IRequest.IsUnique"/> is <see langword="true"/>.</exception>
+        public object ResolveSingle(IRequest request)
+        {
+            return this.Parent.ResolveSingle(request);
+        }
+
+        /// <summary>
         /// Creates a request for the specified service.
         /// </summary>
         /// <param name="service">The service that is being requested.</param>

--- a/src/Ninject/IReadOnlyKernel.cs
+++ b/src/Ninject/IReadOnlyKernel.cs
@@ -23,6 +23,7 @@ namespace Ninject
 {
     using System;
 
+    using Ninject.Activation;
     using Ninject.Planning.Bindings;
     using Ninject.Syntax;
 

--- a/src/Ninject/KernelBase.cs
+++ b/src/Ninject/KernelBase.cs
@@ -384,6 +384,20 @@ namespace Ninject
         {
             return this.ReadOnlyKernel.GetService(serviceType);
         }
+
+        /// <summary>
+        /// Resolves an instance for the specified request.
+        /// </summary>
+        /// <param name="request">The request to resolve.</param>
+        /// <returns>
+        /// An instance that matches the request.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ActivationException">More than one matching bindings is available for the request, and <see cref="IRequest.IsUnique"/> is <see langword="true"/>.</exception>
+        public object ResolveSingle(IRequest request)
+        {
+            return this.ReadOnlyKernel.ResolveSingle(request);
+        }
     }
 }
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Ninject/Planning/Targets/Target.cs
+++ b/src/Ninject/Planning/Targets/Target.cs
@@ -179,7 +179,7 @@ namespace Ninject.Planning.Targets
 
             var request = parent.Request.CreateChild(this.Type, parent, this);
             request.IsUnique = true;
-            return parent.Kernel.Resolve(request).SingleOrDefault();
+            return parent.Kernel.ResolveSingle(request);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace Ninject.Planning.Targets
 
             var request = parent.Request.CreateChild(service, parent, this);
             request.IsUnique = true;
-            return parent.Kernel.Resolve(request).SingleOrDefault();
+            return parent.Kernel.ResolveSingle(request);
         }
 
         /// <summary>

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -578,8 +578,10 @@ namespace Ninject
                 return this.CreateContext(request, satisfiedBinding).Resolve();
             }
 
-            // We can end up here if there are no bindings for the service, or if there's no binding that satisfies
-            // the request.
+            /*
+            / We end up here if there are no bindings for the service, or if there's no binding that satisfies
+            / the request.
+            */
 
             if (handleMissingBindings && this.HandleMissingBinding(request))
             {

--- a/src/Ninject/Syntax/IResolutionRoot.cs
+++ b/src/Ninject/Syntax/IResolutionRoot.cs
@@ -75,6 +75,17 @@ namespace Ninject.Syntax
         IEnumerable<object> Resolve(IRequest request);
 
         /// <summary>
+        /// Resolves an instance for the specified request.
+        /// </summary>
+        /// <param name="request">The request to resolve.</param>
+        /// <returns>
+        /// An instance that matches the request.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ActivationException">More than one matching bindings is available for the request, and <see cref="IRequest.IsUnique"/> is <see langword="true"/>.</exception>
+        object ResolveSingle(IRequest request);
+
+        /// <summary>
         /// Creates a request for the specified service.
         /// </summary>
         /// <param name="service">The service that is being requested.</param>
@@ -83,7 +94,7 @@ namespace Ninject.Syntax
         /// <param name="isOptional"><see langword="true"/> if the request is optional; otherwise, <see langword="false"/>.</param>
         /// <param name="isUnique"><see langword="true"/> if the request should return a unique result; otherwise, <see langword="false"/>.</param>
         /// <returns>
-        /// The created request.
+        /// The request for the specified service.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="service"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is <see langword="null"/>.</exception>

--- a/src/Ninject/Syntax/ResolutionExtensions.cs
+++ b/src/Ninject/Syntax/ResolutionExtensions.cs
@@ -46,7 +46,7 @@ namespace Ninject
         /// </returns>
         public static T Get<T>(this IResolutionRoot root, params IParameter[] parameters)
         {
-            return GetResolutionIterator(root, typeof(T), null, parameters, false, true).Cast<T>().Single();
+            return (T)ResolveSingle(root, typeof(T), null, parameters, false, true);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace Ninject
         /// </returns>
         public static T Get<T>(this IResolutionRoot root, string name, params IParameter[] parameters)
         {
-            return GetResolutionIterator(root, typeof(T), b => b.Name == name, parameters, false, true).Cast<T>().Single();
+            return (T)ResolveSingle(root, typeof(T), b => b.Name == name, parameters, false, true);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Ninject
         /// </returns>
         public static T Get<T>(this IResolutionRoot root, Func<IBindingMetadata, bool> constraint, params IParameter[] parameters)
         {
-            return GetResolutionIterator(root, typeof(T), constraint, parameters, false, true).Cast<T>().Single();
+            return (T)ResolveSingle(root, typeof(T), constraint, parameters, false, true);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Ninject
         /// </returns>
         public static T TryGet<T>(this IResolutionRoot root, params IParameter[] parameters)
         {
-            return TryGet(() => GetResolutionIterator(root, typeof(T), null, parameters, true, true).Cast<T>());
+            return TryGet<T>(() => ResolveSingle(root, typeof(T), null, parameters, true, true));
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Ninject
         /// </returns>
         public static T TryGet<T>(this IResolutionRoot root, string name, params IParameter[] parameters)
         {
-            return TryGet(() => GetResolutionIterator(root, typeof(T), b => b.Name == name, parameters, true, true).Cast<T>());
+            return TryGet<T>(() => ResolveSingle(root, typeof(T), b => b.Name == name, parameters, true, true));
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Ninject
         /// </returns>
         public static T TryGet<T>(this IResolutionRoot root, Func<IBindingMetadata, bool> constraint, params IParameter[] parameters)
         {
-            return TryGet(() => GetResolutionIterator(root, typeof(T), constraint, parameters, true, true).Cast<T>());
+            return TryGet<T>(() => ResolveSingle(root, typeof(T), constraint, parameters, true, true));
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace Ninject
         /// </returns>
         public static object Get(this IResolutionRoot root, Type service, params IParameter[] parameters)
         {
-            return GetResolutionIterator(root, service, null, parameters, false, true).Single();
+            return ResolveSingle(root, service, null, parameters, false, true);
         }
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Ninject
         /// </returns>
         public static object Get(this IResolutionRoot root, Type service, string name, params IParameter[] parameters)
         {
-            return GetResolutionIterator(root, service, b => b.Name == name, parameters, false, true).Single();
+            return ResolveSingle(root, service, b => b.Name == name, parameters, false, true);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Ninject
         /// </returns>
         public static object Get(this IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, params IParameter[] parameters)
         {
-            return GetResolutionIterator(root, service, constraint, parameters, false, true).Single();
+            return ResolveSingle(root, service, constraint, parameters, false, true);
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace Ninject
         /// </returns>
         public static object TryGet(this IResolutionRoot root, Type service, params IParameter[] parameters)
         {
-            return TryGet(() => GetResolutionIterator(root, service, null, parameters, true, true));
+            return TryGet(() => ResolveSingle(root, service, null, parameters, true, true));
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace Ninject
         /// </returns>
         public static object TryGet(this IResolutionRoot root, Type service, string name, params IParameter[] parameters)
         {
-            return TryGet(() => GetResolutionIterator(root, service, b => b.Name == name, parameters, true, false));
+            return TryGet(() => ResolveSingle(root, service, b => b.Name == name, parameters, true, false));
         }
 
         /// <summary>
@@ -296,7 +296,7 @@ namespace Ninject
         /// </returns>
         public static object TryGet(this IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, params IParameter[] parameters)
         {
-            return TryGet(() => GetResolutionIterator(root, service, constraint, parameters, true, false));
+            return TryGet(() => ResolveSingle(root, service, constraint, parameters, true, false));
         }
 
         /// <summary>
@@ -439,6 +439,14 @@ namespace Ninject
             return root.CanResolve(request);
         }
 
+        private static object ResolveSingle(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IReadOnlyList<IParameter> parameters, bool isOptional, bool isUnique)
+        {
+            Ensure.ArgumentNotNull(root, nameof(root));
+
+            var request = root.CreateRequest(service, constraint, parameters, isOptional, isUnique);
+            return root.ResolveSingle(request);
+        }
+
         private static IEnumerable<object> GetResolutionIterator(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IReadOnlyList<IParameter> parameters, bool isOptional, bool isUnique)
         {
             Ensure.ArgumentNotNull(root, nameof(root));
@@ -447,20 +455,11 @@ namespace Ninject
             return root.Resolve(request);
         }
 
-        private static IEnumerable<object> GetResolutionIterator(IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, IReadOnlyList<IParameter> parameters, bool isOptional, bool isUnique, bool forceUnique)
-        {
-            Ensure.ArgumentNotNull(root, nameof(root));
-
-            var request = root.CreateRequest(service, constraint, parameters, isOptional, isUnique);
-            request.ForceUnique = forceUnique;
-            return root.Resolve(request);
-        }
-
-        private static T TryGet<T>(Func<IEnumerable<T>> iterator)
+        private static T TryGet<T>(Func<object> resolver)
         {
             try
             {
-                return iterator().SingleOrDefault();
+                return (T)resolver();
             }
             catch (ActivationException)
             {
@@ -468,9 +467,25 @@ namespace Ninject
             }
         }
 
+        private static object TryGet(Func<object> resolver)
+        {
+            try
+            {
+                return resolver();
+            }
+            catch (ActivationException)
+            {
+                return null;
+            }
+        }
+
         private static T DoTryGetAndThrowOnInvalidBinding<T>(IResolutionRoot root, Func<IBindingMetadata, bool> constraint, IReadOnlyList<IParameter> parameters)
         {
-            return GetResolutionIterator(root, typeof(T), constraint, parameters, true, true, true).Cast<T>().SingleOrDefault();
+            Ensure.ArgumentNotNull(root, nameof(root));
+
+            var request = root.CreateRequest(typeof(T), constraint, parameters, true, true);
+            request.ForceUnique = true;
+            return (T)root.ResolveSingle(request);
         }
     }
 }


### PR DESCRIPTION
Added an `object ResolveSingle(IRequest request)` method to **IResolutionRoot** which is optimized for resolving a single instance of a given service.

This new method is used in the **Get**, **TryGet** and **TryGetAndThrowOnInvalidBinding** extension methods.

Result of the [IocPerformance](https://github.com/danielpalme/IocPerformance) benchmark with activation cache disabled:

**PR:**

Test | Singlethreaded | Multithreaded
-----|----------------:|--------------:
  Singleton |       392    |    446
 Transient  |      883     |   568
 Combined   |     2683     |  1921
 Complex    |     8378     |  5949

**master:**

Test | Singlethreaded | Multithreaded
-----|----------------:|--------------:
Singleton  |      574     |   590
 Transient  |     1069    |    716
 Combined    |    3347    |   2011
 Complex      |  10640     |  7331

**3.3.4.0:**

Test | Singlethreaded | Multithreaded
-----|----------------:|--------------:
Singleton  |     1779     |  1275
 Transient  |     4385     |  2638
 Combined   |    12384     |  8018
 Complex    |    35433     | 23947 