### PR TITLE
Do not attempt to handle unbound generic type definition as collection.

### DIFF
--- a/src/Ninject.Test/Integration/ReadOnlyKernelTests.cs
+++ b/src/Ninject.Test/Integration/ReadOnlyKernelTests.cs
@@ -689,8 +689,7 @@ namespace Ninject.Tests.Integration
                 bindings.Should().HaveCount(2);
             }
 
-
-            [Fact(Skip = "https://github.com/ninject/Ninject/issues/340")]
+            [Fact]
             public void TryGet_ServiceAndConstraintAndParameters_ReturnsNullWhenTypeIsUnboundGenericTypeDefinition()
             {
                 var service = typeof(List<>);
@@ -799,7 +798,7 @@ namespace Ninject.Tests.Integration
                 bindings.Should().BeEmpty();
             }
 
-            [Fact(Skip = "https://github.com/ninject/Ninject/issues/340")]
+            [Fact]
             public void TryGet_ServiceAndConstraintAndParameters_ReturnsNullWhenTypeIsUnboundGenericTypeDefinition()
             {
                 var service = typeof(List<>);

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -492,7 +492,7 @@ namespace Ninject
                 return this.ResolveAll(request, false).CastSlow(service).ToArraySlow(service);
             }
 
-            if (request.Service.IsGenericType)
+            if (request.Service.IsGenericType && !request.Service.IsGenericTypeDefinition)
             {
                 var gtd = request.Service.GetGenericTypeDefinition();
 


### PR DESCRIPTION
Do not attempt to handle unbound generic type definition as collection.
Fixes #340.