### PR TITLE
Avoid stackoverflow when handling missing bindings, and no bindings match

### DIFF
--- a/src/Ninject.Test/Integration/ReadOnlyKernelTests.cs
+++ b/src/Ninject.Test/Integration/ReadOnlyKernelTests.cs
@@ -96,7 +96,7 @@ namespace Ninject.Tests.Integration
                 bindings.Should().HaveCount(1);
             }
 
-            [Fact(Skip = "https://github.com/ninject/Ninject/issues/341")]
+            [Fact]
             public void TryGetOfT_NameAndParameters_ReturnsNullWhenNoMatchingBindingExistsAndRegistersImplicitSelfBindingIfTypeIsSelfBindable()
             {
                 Kernel = Configuration.BuildReadOnlyKernel();
@@ -110,7 +110,7 @@ namespace Ninject.Tests.Integration
                 bindings.Should().OnlyContain(b => b.IsImplicit);
             }
 
-            [Fact(Skip = "https://github.com/ninject/Ninject/issues/341")]
+            [Fact]
             public void TryGet_ServiceAndNameAndParameters_ReturnsNullWhenNoMatchingBindingExistsAndRegistersImplicitSelfBindingIfTypeIsSelfBindable()
             {
                 Kernel = Configuration.BuildReadOnlyKernel();

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -457,7 +457,7 @@ namespace Ninject
 
             if (handleMissingBindings && this.HandleMissingBinding(request))
             {
-                return this.ResolveSingle(request, true);
+                return this.ResolveSingle(request, false);
             }
 
             if (request.IsOptional)
@@ -585,7 +585,7 @@ namespace Ninject
 
             if (handleMissingBindings && this.HandleMissingBinding(request))
             {
-                return this.ResolveSingle(request, true);
+                return this.ResolveSingle(request, false);
             }
 
             if (request.IsOptional)


### PR DESCRIPTION
Avoid stackoverflow when handling missing bindings, and none of the bindings match.
Fixes #341.