### PR TITLE
Fixing IServiceProvider.GetService implementation (fixes #376)

### DIFF
--- a/src/Ninject.Test/Integration/StandardKernelTests.cs
+++ b/src/Ninject.Test/Integration/StandardKernelTests.cs
@@ -585,6 +585,20 @@
             var provider = this.kernel as IServiceProvider;
             provider.GetService(typeof(Samurai)).Should().BeNull();
         }
+
+        [Fact]
+        public void ItThrowsWhenServiceIsNotConfiguredAndSettingThrowOnGetServiceNotFound()
+        {
+            using (var kernel = new StandardKernel(new NinjectSettings
+            {
+                ThrowOnGetServiceNotFound = true
+            }))
+            {
+                var provider = kernel as IServiceProvider;
+                Action resolveAction = () => provider.GetService(typeof(Samurai));
+                resolveAction.Should().Throw<ActivationException>();
+            }
+        }
     }
 
     public class InitializableA : IInitializable

--- a/src/Ninject.Test/Integration/StandardKernelTests.cs
+++ b/src/Ninject.Test/Integration/StandardKernelTests.cs
@@ -567,7 +567,26 @@
             }
         }
     }
-    
+
+    public class WhenServiceIsResolvedThroughServiceProviderInterface : StandardKernelContext
+    {
+        [Fact]
+        public void ItResolvesBoundService()
+        {
+            this.kernel.Bind<IWeapon>().To<Sword>();
+
+            var provider = this.kernel as IServiceProvider;
+            provider.GetService(typeof(IWeapon)).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ItReturnsNullWhenServiceIsNotConfigured()
+        {
+            var provider = this.kernel as IServiceProvider;
+            provider.GetService(typeof(Samurai)).Should().BeNull();
+        }
+    }
+
     public class InitializableA : IInitializable
     {
         public static int Count = 0;

--- a/src/Ninject/INinjectSettings.cs
+++ b/src/Ninject/INinjectSettings.cs
@@ -123,5 +123,13 @@ namespace Ninject
         /// is <see langword="true"/>.
         /// </value>
         bool PropertyInjection { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the old (&lt;= 3.3.4) behavior of <see cref="IServiceProvider.GetService(Type)"/>
+        /// should be used which thorows an exception if the requested service cannot be found. Note that the documentation
+        /// of that method https://docs.microsoft.com/en-us/dotnet/api/system.iserviceprovider.getservice?view=netframework-4.6.2
+        /// states that the method should return <see langword="null"/> if there is no such service.
+        /// </summary>
+        bool ThrowOnGetServiceNotFound { get; set; }
     }
 }

--- a/src/Ninject/NinjectSettings.cs
+++ b/src/Ninject/NinjectSettings.cs
@@ -166,5 +166,13 @@ namespace Ninject
         /// is <see langword="true"/>.
         /// </value>
         public bool PropertyInjection { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the old (&lt;= 3.3.4) behavior of <see cref="IServiceProvider.GetService(Type)"/>
+        /// should be used which thorows an exception if the requested service cannot be found. Note that the documentation
+        /// of that method https://docs.microsoft.com/en-us/dotnet/api/system.iserviceprovider.getservice?view=netframework-4.6.2
+        /// states that the method should return <see langword="null"/> if there is no such service.
+        /// </summary>
+        public bool ThrowOnGetServiceNotFound { get; set; }
     }
 }

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -246,7 +246,7 @@ namespace Ninject
         {
             Ensure.ArgumentNotNull(serviceType, nameof(serviceType));
 
-            return this.Get(serviceType);
+            return this.TryGet(serviceType);
         }
 
         /// <summary>

--- a/src/Ninject/ReadOnlyKernel.cs
+++ b/src/Ninject/ReadOnlyKernel.cs
@@ -246,7 +246,9 @@ namespace Ninject
         {
             Ensure.ArgumentNotNull(serviceType, nameof(serviceType));
 
-            return this.TryGet(serviceType);
+            return this.settings.ThrowOnGetServiceNotFound
+                ? this.Get(serviceType)
+                : this.TryGet(serviceType);
         }
 
         /// <summary>


### PR DESCRIPTION
The problem is described in https://github.com/ninject/Ninject/issues/376 and the solution is straight forward. I have added two test cases for the `StandardKernel` to ensure that the `IServiceProvider` implementation is compliant with the behavior defined in the documentation.