### PR TITLE
Consolidated handling of isUnique parameter for TryGet (fixes #378)

### DIFF
--- a/src/Ninject.Test/Integration/ReadOnlyKernelTests.cs
+++ b/src/Ninject.Test/Integration/ReadOnlyKernelTests.cs
@@ -360,8 +360,8 @@ namespace Ninject.Tests.Integration
                 bindings.Should().OnlyContain(b => !b.IsImplicit);
             }
 
-            [Fact(Skip = "Unique?")]
-            public void TryGet_ServiceAndNameAndParameters_ResolvesUsingFirstMatchingBindingWhenTypeIsSelfBinding()
+            [Fact()]
+            public void TryGet_ServiceAndNameAndParameters_WhenTypeIsSelfBinding()
             {
                 var service = typeof(Sword);
 
@@ -371,8 +371,7 @@ namespace Ninject.Tests.Integration
                 Kernel = Configuration.BuildReadOnlyKernel();
 
                 var weapon = Kernel.TryGet(service, "a", Array.Empty<IParameter>());
-                weapon.Should().NotBeNull();
-                weapon.Should().BeOfType<Sword>();
+                weapon.Should().BeNull();
 
                 var bindings = Kernel.GetBindings(service);
                 bindings.Should().HaveCount(2);
@@ -380,8 +379,8 @@ namespace Ninject.Tests.Integration
             }
 
 
-            [Fact(Skip = "Unique?")]
-            public void TryGet_ServiceAndNameAndParameters_ResolvesUsingFirstMatchingBindingWhenTypeIsNotSelfBinding()
+            [Fact()]
+            public void TryGet_ServiceAndNameAndParameters_WhenTypeIsNotSelfBinding()
             {
                 var service = typeof(IWeapon);
 
@@ -391,16 +390,15 @@ namespace Ninject.Tests.Integration
                 Kernel = Configuration.BuildReadOnlyKernel();
 
                 var weapon = Kernel.TryGet(service, "a", Array.Empty<IParameter>());
-                weapon.Should().NotBeNull();
-                weapon.Should().BeOfType<Sword>();
+                weapon.Should().BeNull();
 
                 var bindings = Kernel.GetBindings(service);
                 bindings.Should().HaveCount(2);
                 bindings.Should().OnlyContain(b => !b.IsImplicit);
             }
 
-            [Fact(Skip = "Unique?")]
-            public void TryGet_ServiceAndConstraintAndParameters_ResolvesUsingFirstMatchingBindingWhenTypeIsSelfBinding()
+            [Fact()]
+            public void TryGet_ServiceAndConstraintAndParameters_WhenTypeIsSelfBinding()
             {
                 var service = typeof(Sword);
 
@@ -412,16 +410,15 @@ namespace Ninject.Tests.Integration
 
                 var weapon = Kernel.TryGet(service, (metadata) => metadata.Name == "a", Array.Empty<IParameter>());
 
-                weapon.Should().NotBeNull();
-                weapon.Should().BeOfType<Sword>();
+                weapon.Should().BeNull();
 
                 var bindings = Kernel.GetBindings(service);
                 bindings.Should().HaveCount(3);
                 bindings.Should().OnlyContain(b => !b.IsImplicit);
             }
 
-            [Fact(Skip ="Unique?")]
-            public void TryGet_ServiceAndConstraintAndParameters_ResolvesUsingFirstMatchingBindingWhenTypeIsNotSelfBindingAndNotGeneric()
+            [Fact()]
+            public void TryGet_ServiceAndConstraintAndParameters_WhenTypeIsNotSelfBindingAndNotGeneric()
             {
                 var service = typeof(IWeapon);
 
@@ -432,8 +429,7 @@ namespace Ninject.Tests.Integration
 
                 var weapon = Kernel.TryGet(service, (metadata) => metadata.Name == "a", Array.Empty<IParameter>());
 
-                weapon.Should().NotBeNull();
-                weapon.Should().BeOfType<Sword>();
+                weapon.Should().BeNull();
 
                 var bindings = Kernel.GetBindings(service);
                 bindings.Should().HaveCount(2);

--- a/src/Ninject/Syntax/ResolutionExtensions.cs
+++ b/src/Ninject/Syntax/ResolutionExtensions.cs
@@ -281,7 +281,7 @@ namespace Ninject
         /// </returns>
         public static object TryGet(this IResolutionRoot root, Type service, string name, params IParameter[] parameters)
         {
-            return TryGet(() => ResolveSingle(root, service, b => b.Name == name, parameters, true, false));
+            return TryGet(() => ResolveSingle(root, service, b => b.Name == name, parameters, true, true));
         }
 
         /// <summary>
@@ -296,7 +296,7 @@ namespace Ninject
         /// </returns>
         public static object TryGet(this IResolutionRoot root, Type service, Func<IBindingMetadata, bool> constraint, params IParameter[] parameters)
         {
-            return TryGet(() => ResolveSingle(root, service, constraint, parameters, true, false));
+            return TryGet(() => ResolveSingle(root, service, constraint, parameters, true, true));
         }
 
         /// <summary>


### PR DESCRIPTION
This should fix #378.

All of the generic `TryGet<T>` overloads and _one_ of the three `TryGet` overloads already set `isUnique` to `true`. The other two are the outliers that behave in a way that is inconsistent with the documented/expected behavior of the method.