### PR TITLE
Check for useless ConstructorArgument.

### DIFF
--- a/src/Ninject.Test/Unit/UselessConstructorArgumentTests.cs
+++ b/src/Ninject.Test/Unit/UselessConstructorArgumentTests.cs
@@ -1,0 +1,77 @@
+﻿namespace Ninject.Tests.Unit
+{
+    using System;
+    using FluentAssertions;
+    using Ninject;
+    using Xunit;
+
+    public class UselessConstructorArgumentTests
+    {
+        public UselessConstructorArgumentTests()
+        {
+        }
+
+        [Fact]
+        public void UselessConstructorArgument_FailedTest()
+        {
+            using (var kernel = new StandardKernel())
+            {
+                kernel.Settings.CheckForUselessConstructorArgument = true;
+
+                kernel.Bind<PulseLaser>().ToSelf()
+                    .WithConstructorArgument("power", 100)
+                    .WithConstructorArgument("pulseInterval", TimeSpan.FromSeconds(1))
+                    .WithConstructorArgument("unknownArgument", 1)
+                    ;
+
+                Action getLaser = () => kernel.Get<PulseLaser>();
+
+                getLaser.ShouldThrow<ActivationException>();
+            }
+        }
+
+        [Fact]
+        public void UselessConstructorArgument_SuccessfulTest()
+        {
+            using (var kernel = new StandardKernel())
+            {
+                kernel.Settings.CheckForUselessConstructorArgument = false;
+
+                kernel.Bind<PulseLaser>().ToSelf()
+                    .WithConstructorArgument("power", 100)
+                    .WithConstructorArgument("pulseInterval", TimeSpan.FromSeconds(1))
+                    .WithConstructorArgument("unknownArgument", 1)
+                    ;
+
+                var pulseLaser = kernel.Get<PulseLaser>();
+                pulseLaser.Should().NotBeNull();
+                pulseLaser.Power.Should().Be(100);
+                pulseLaser.PulseInterval.Should().Be(TimeSpan.FromSeconds(1));
+            }
+        }
+    }
+
+    public class Laser
+    {
+        public readonly int Power;
+
+        public Laser(
+            int power
+            )
+        {
+            Power = power;
+        }
+    }
+
+    public sealed class PulseLaser : Laser
+    {
+        public readonly TimeSpan PulseInterval;
+
+        public PulseLaser(int power, TimeSpan pulseInterval)
+            : base(power)
+        {
+            PulseInterval = pulseInterval;
+        }
+    }
+
+}

--- a/src/Ninject/Activation/Providers/StandardProvider.cs
+++ b/src/Ninject/Activation/Providers/StandardProvider.cs
@@ -115,6 +115,33 @@ namespace Ninject.Activation.Providers
 
             var directive = this.DetermineConstructorInjectionDirective(context);
 
+            #region check if any constructor argument is useless; fail if so
+
+            if (context.Kernel.Settings.CheckForUselessConstructorArgument)
+            {
+                foreach (IConstructorArgument constructorArgument in context.Parameters.OfType<IConstructorArgument>())
+                {
+                    var cpn = constructorArgument.Name;
+
+                    var match = false;
+                    foreach (var target in directive.Targets)
+                    {
+                        if (constructorArgument.AppliesToTarget(context, target))
+                        {
+                            match = true;
+                            break;
+                        }
+                    }
+
+                    if (!match)
+                    {
+                        throw new Ninject.ActivationException($"Boom");
+                    }
+                }
+            }
+
+            #endregion
+
             var arguments = directive.Targets.Select(target => this.GetValue(context, target)).ToArray();
 
             var cachedInstance = context.Cache.TryGet(context);

--- a/src/Ninject/INinjectSettings.cs
+++ b/src/Ninject/INinjectSettings.cs
@@ -104,6 +104,13 @@ namespace Ninject
         /// </summary>
         bool ThrowOnGetServiceNotFound { get; set; }
 
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Ninject should seek for a useless constructor arguments in the binding
+        /// and fail the resolution process if it found.
+        /// </summary>
+        bool CheckForUselessConstructorArgument { get; set; }
+
         /// <summary>
         /// Gets the value for the specified key.
         /// </summary>

--- a/src/Ninject/NinjectSettings.cs
+++ b/src/Ninject/NinjectSettings.cs
@@ -155,6 +155,16 @@ namespace Ninject
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether Ninject should seek for a useless constructor arguments in the binding
+        /// and fail the resolution process if it found.
+        /// </summary>
+        public bool CheckForUselessConstructorArgument
+        {
+            get { return this.Get("CheckForUselessConstructorArgument", false); }
+            set { this.Set("CheckForUselessConstructorArgument", value); }
+        }
+
+        /// <summary>
         /// Gets the value for the specified key.
         /// </summary>
         /// <typeparam name="T">The type of value to return.</typeparam>


### PR DESCRIPTION
I'd want to add to Ninject a feature for checking for an useless `ConstructorArgument` and fail the resolution process if it found.

I have prototyped the PR, please take a look. I understand that this PR is not ready to merge, I want to ask maintainers for a remarks.

(If it will be approved, I would suggest to enable the new setting to be `True` by default in 4.0.0 release)

Side note: I'd created my branch from 3.3.6 tag commit, and I had a difficulty when choosing a target branch for PR. Please change the target branch if I pick the wrong one.